### PR TITLE
feat: implement side panel view mode and settings options

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,6 +1,22 @@
+import { storageService } from "@/services/storage";
+import { SyncStorageKey } from "@/services/storage/types";
 import { routeCommand, routeMessage } from "./router";
 
 export default defineBackground(() => {
+  // サイドパネルの初期化
+  storageService.getViewMode().then((viewMode) => {
+    chrome.sidePanel
+      .setPanelBehavior({ openPanelOnActionClick: viewMode === "sidepanel" })
+      .catch(console.error);
+  });
+
+  // viewMode変更時にサイドパネルの動作を更新
+  storageService.subscribe(SyncStorageKey.ViewMode, (viewMode) => {
+    chrome.sidePanel
+      .setPanelBehavior({ openPanelOnActionClick: viewMode === "sidepanel" })
+      .catch(console.error);
+  });
+
   /**
    * @description コマンドのルーティング
    */

--- a/src/entrypoints/background/router/command.ts
+++ b/src/entrypoints/background/router/command.ts
@@ -1,14 +1,20 @@
 import { contentService } from "@/services/content";
 import { MessageType } from "@/services/runtime/types";
+import { storageService } from "@/services/storage";
 
-export const routeCommand = (command: string, _tab: chrome.tabs.Tab) => {
+export const routeCommand = async (command: string, tab: chrome.tabs.Tab) => {
   switch (command) {
     case MessageType.OPEN_POPUP: {
-      contentService.open({}).then((res) => {
-        if (!res.success) {
-          chrome.runtime.sendMessage({ type: "CLOSE_POPUP" });
-        }
-      });
+      const viewMode = await storageService.getViewMode();
+      if (viewMode === "sidepanel" && tab.id) {
+        await chrome.sidePanel.open({ tabId: tab.id });
+      } else {
+        contentService.open({}).then((res) => {
+          if (!res.success) {
+            chrome.runtime.sendMessage({ type: "CLOSE_POPUP" });
+          }
+        });
+      }
       return true;
     }
     default:

--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -8,8 +8,14 @@ import {
   type UpdateTabRequest,
 } from "@/services/tab";
 
-const { OPEN_POPUP, CREATE_TAB, UPDATE_TAB, REMOVE_TAB, QUERY_RESULT } =
-  MessageType;
+const {
+  OPEN_POPUP,
+  CREATE_TAB,
+  UPDATE_TAB,
+  REMOVE_TAB,
+  QUERY_RESULT,
+  SWITCH_VIEW_MODE,
+} = MessageType;
 
 function sendResponse(
   type: string,
@@ -21,6 +27,7 @@ function sendResponse(
 
 type Message =
   | { type: "OPEN_POPUP" }
+  | { type: "SWITCH_VIEW_MODE" }
   | CreateTabRequest
   | UpdateTabRequest
   | RemoveTabRequest
@@ -68,6 +75,13 @@ export function routeMessage(
         .catch((error) => {
           console.error("Error handling QUERY_RESULT:", error);
         });
+      return true;
+    }
+
+    case SWITCH_VIEW_MODE: {
+      // ユーザージェスチャートークンが有効なうちに同期的に呼ぶ
+      chrome.action.openPopup().catch(console.error);
+      sendResponse(SWITCH_VIEW_MODE, true, response);
       return true;
     }
 

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -6,7 +6,7 @@ import Squares2X2Icon from "@heroicons/react/16/solid/Squares2X2Icon";
 import SunIcon from "@heroicons/react/16/solid/SunIcon";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import clsx from "clsx";
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 import useViewMode from "@/features/settings/hooks/useViewMode";
 import { ThemeContext } from "@/features/theme/context/ThemeProvider";
 import type { ThemeValue, ViewModeValue } from "@/services/storage/types";
@@ -37,6 +37,22 @@ function OptionsContent() {
   const { t } = useTranslation();
   const { theme, setTheme } = useContext(ThemeContext);
   const { viewMode, setViewMode } = useViewMode();
+
+  const handleViewModeChange = useCallback(
+    async (value: ViewModeValue) => {
+      setViewMode(value);
+      if (value === "sidepanel") {
+        const [tab] = await chrome.tabs.query({
+          active: true,
+          lastFocusedWindow: true,
+        });
+        if (tab?.id) {
+          await chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
+        }
+      }
+    },
+    [setViewMode],
+  );
 
   const themes: { value: ThemeValue; label: string }[] = [
     { value: "light", label: t("theme.light") },
@@ -85,7 +101,7 @@ function OptionsContent() {
             <button
               key={item.value}
               type="button"
-              onClick={() => setViewMode(item.value)}
+              onClick={() => handleViewModeChange(item.value)}
               className={clsx(
                 "flex items-center w-full px-4 py-3 rounded-lg border-2 transition-colors",
                 viewMode === item.value

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -1,0 +1,115 @@
+import "@/assets/global.css";
+import ComputerDesktopIcon from "@heroicons/react/16/solid/ComputerDesktopIcon";
+import MoonIcon from "@heroicons/react/16/solid/MoonIcon";
+import RectangleGroupIcon from "@heroicons/react/16/solid/RectangleGroupIcon";
+import Squares2X2Icon from "@heroicons/react/16/solid/Squares2X2Icon";
+import SunIcon from "@heroicons/react/16/solid/SunIcon";
+import { CheckCircleIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+import { useContext } from "react";
+import useViewMode from "@/features/settings/hooks/useViewMode";
+import { ThemeContext } from "@/features/theme/context/ThemeProvider";
+import type { ThemeValue, ViewModeValue } from "@/services/storage/types";
+import Layout from "@/shared/components/Layout/Layout";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+
+const ThemeIcon = (props: { theme: ThemeValue; className?: string }) => {
+  switch (props.theme) {
+    case "light":
+      return <SunIcon className={props.className} />;
+    case "dark":
+      return <MoonIcon className={props.className} />;
+    default:
+      return <ComputerDesktopIcon className={props.className} />;
+  }
+};
+
+const ViewModeIcon = (props: { mode: ViewModeValue; className?: string }) => {
+  switch (props.mode) {
+    case "sidepanel":
+      return <RectangleGroupIcon className={props.className} />;
+    default:
+      return <Squares2X2Icon className={props.className} />;
+  }
+};
+
+function OptionsContent() {
+  const { t } = useTranslation();
+  const { theme, setTheme } = useContext(ThemeContext);
+  const { viewMode, setViewMode } = useViewMode();
+
+  const themes: { value: ThemeValue; label: string }[] = [
+    { value: "light", label: t("theme.light") },
+    { value: "dark", label: t("theme.dark") },
+    { value: "system", label: t("theme.system") },
+  ];
+
+  const modes: { value: ViewModeValue; label: string }[] = [
+    { value: "popup", label: t("viewMode.popup") },
+    { value: "sidepanel", label: t("viewMode.sidepanel") },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-200 p-8">
+      <h1 className="text-2xl font-bold mb-8">{t("settings.title")}</h1>
+
+      <section className="mb-8 max-w-md">
+        <h2 className="text-lg font-semibold mb-4">{t("settings.theme")}</h2>
+        <div className="space-y-2">
+          {themes.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => setTheme(item.value)}
+              className={clsx(
+                "flex items-center w-full px-4 py-3 rounded-lg border-2 transition-colors",
+                theme === item.value
+                  ? "border-sky-500 bg-sky-50 dark:bg-sky-900/30"
+                  : "border-gray-200 dark:border-gray-700 hover:border-sky-300 dark:hover:border-sky-700",
+              )}
+            >
+              <ThemeIcon theme={item.value} className="size-5 mr-3" />
+              <span className="flex-1 text-left">{item.label}</span>
+              {theme === item.value && (
+                <CheckCircleIcon className="size-5 text-sky-500" />
+              )}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="max-w-md">
+        <h2 className="text-lg font-semibold mb-4">{t("settings.viewMode")}</h2>
+        <div className="space-y-2">
+          {modes.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => setViewMode(item.value)}
+              className={clsx(
+                "flex items-center w-full px-4 py-3 rounded-lg border-2 transition-colors",
+                viewMode === item.value
+                  ? "border-sky-500 bg-sky-50 dark:bg-sky-900/30"
+                  : "border-gray-200 dark:border-gray-700 hover:border-sky-300 dark:hover:border-sky-700",
+              )}
+            >
+              <ViewModeIcon mode={item.value} className="size-5 mr-3" />
+              <span className="flex-1 text-left">{item.label}</span>
+              {viewMode === item.value && (
+                <CheckCircleIcon className="size-5 text-sky-500" />
+              )}
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <Layout>
+      <OptionsContent />
+    </Layout>
+  );
+}

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zen Search - Settings</title>
+    <link rel="stylesheet" href="@/assets/global.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -3,7 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 
 const rootElement =
-  document.getElementById("root") ?? document.createElement("div");
+  document.getElementById("root") ??
+  (() => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    return div;
+  })();
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+const rootElement =
+  document.getElementById("root") ?? document.createElement("div");
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -1,5 +1,5 @@
 import SearchApp from "@/features/search/components/SearchApp/SearchApp";
 
 export default function App() {
-  return <SearchApp onClose={() => window.close()} />;
+  return <SearchApp variant="sidepanel" />;
 }

--- a/src/entrypoints/sidepanel/index.html
+++ b/src/entrypoints/sidepanel/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/entrypoints/sidepanel/index.html
+++ b/src/entrypoints/sidepanel/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zen Search</title>
+    <link rel="stylesheet" href="@/assets/global.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -3,7 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 
 const rootElement =
-  document.getElementById("root") ?? document.createElement("div");
+  document.getElementById("root") ??
+  (() => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    return div;
+  })();
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+const rootElement =
+  document.getElementById("root") ?? document.createElement("div");
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/features/action/components/CalculationItem/CalculationItem.tsx
+++ b/src/features/action/components/CalculationItem/CalculationItem.tsx
@@ -49,7 +49,7 @@ const CalculationItem: React.FC<CalculationItemProps> = ({
   const RightIcon = useMemo(
     () => (
       <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions_openResult")}</span>
+        <span className={defaultClassName.text}>{t("actions.openResult")}</span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(

--- a/src/features/bookmark/components/BookmarkItem/BookmarkItem.tsx
+++ b/src/features/bookmark/components/BookmarkItem/BookmarkItem.tsx
@@ -60,7 +60,7 @@ const BookmarkItem: React.FC<BookmarkItemProps> = ({
   const RightContent = useMemo(
     () => (
       <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions_openTab")}</span>
+        <span className={defaultClassName.text}>{t("actions.openTab")}</span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(

--- a/src/features/history/components/HistoryItem/HistoryItem.tsx
+++ b/src/features/history/components/HistoryItem/HistoryItem.tsx
@@ -55,7 +55,7 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
   const RightContent = useMemo(
     () => (
       <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions_openTab")}</span>
+        <span className={defaultClassName.text}>{t("actions.openTab")}</span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(

--- a/src/features/search/components/ResultFooter/ResultFooter.tsx
+++ b/src/features/search/components/ResultFooter/ResultFooter.tsx
@@ -1,6 +1,6 @@
 import Footer from "@/features/search/components/Footer/Footer";
 import Spinner from "@/features/search/components/Spinner/Spinner";
-import ThemeSelectButton from "@/features/theme/components/ThemeSelectButton/ThemeSelectButton";
+import SettingsButton from "@/features/settings/components/SettingsButton/SettingsButton";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 
 export interface ResultFooterProps {
@@ -19,7 +19,7 @@ export default function ResultFooter({
     return (
       <Footer className={`text-base ${className}`}>
         <div className="flex flex-row items-center justify-between space-x-2">
-          <ThemeSelectButton className="dark:text-gray-400" />
+          <SettingsButton className="dark:text-gray-400" />
           <div className="flex flex-row items-center justify-center space-x-2">
             <p className="text-gray-400 ">{t("ui.loading")}</p>
             <Spinner active={loading} size="xs" />
@@ -32,7 +32,7 @@ export default function ResultFooter({
   return (
     <Footer className={`text-base ${className}`}>
       <div className="flex flex-row items-center justify-between space-x-2">
-        <ThemeSelectButton className="dark:text-gray-400" />
+        <SettingsButton className="dark:text-gray-400" />
         <p className="text-base font-bold text-right dark:text-gray-400">
           {count ?? 0} {t("ui.results")}
         </p>

--- a/src/features/search/components/ResultList/ResultList.tsx
+++ b/src/features/search/components/ResultList/ResultList.tsx
@@ -7,6 +7,8 @@ export interface ResultListProps {
   ref: React.Ref<HTMLUListElement>;
   selectedIndex?: number;
   onClick?: (item: Result<Kind>) => void;
+  className?: string;
+  listClassName?: string;
 }
 
 const ResultList: React.FC<ResultListProps> = ({
@@ -14,13 +16,15 @@ const ResultList: React.FC<ResultListProps> = ({
   onClick,
   ref,
   selectedIndex,
+  className,
+  listClassName = "max-h-56",
 }) => {
   const hasItems = items.length > 0;
 
   return (
-    <div className="pt-3 pb-2 dark:bg-gray-800">
+    <div className={`pt-3 pb-2 dark:bg-gray-800 ${className ?? ""}`}>
       <ul
-        className="pr-3 space-y-1 overflow-x-hidden overflow-y-auto max-h-56 snap-y snap-mandatory"
+        className={`pr-3 space-y-1 overflow-x-hidden overflow-y-auto snap-y snap-mandatory ${listClassName}`}
         ref={ref}
       >
         {hasItems ? (

--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -1,0 +1,195 @@
+import "@/assets/global.css";
+import MagnifyingGlassIcon from "@heroicons/react/16/solid/MagnifyingGlassIcon";
+import clsx from "clsx";
+import type React from "react";
+import { useCallback } from "react";
+import Badge from "@/features/search/components/Badge/Badge";
+import ResultFooter from "@/features/search/components/ResultFooter/ResultFooter";
+import ResultList from "@/features/search/components/ResultList/ResultList";
+import SearchInput, {
+  commonClassName as searchInputClassName,
+} from "@/features/search/components/SearchInput/SearchInput";
+import SquareBadge from "@/features/search/components/SquareBadge/SquareBadge";
+import useSearch from "@/features/search/hooks/useSearch";
+import useSearchKeyboard from "@/features/search/hooks/useSearchKeyboard";
+import useSearchResults from "@/features/search/hooks/useSearchResults";
+import useSearchShortcut from "@/features/search/hooks/useSearchShortcut";
+import useControlTab from "@/features/tab/hooks/useControlTab";
+import type { Kind, Result } from "@/services/result";
+import Layout, {
+  commonClassName as layoutClassName,
+} from "@/shared/components/Layout/Layout";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+
+export type SearchAppProps = {
+  onClose?: () => void;
+  variant?: "popup" | "sidepanel";
+};
+
+export default function SearchApp({
+  onClose = () => window.close(),
+  variant = "popup",
+}: SearchAppProps) {
+  const { t } = useTranslation();
+
+  const {
+    state: { query, type, suggestion, categories },
+    debouncedQuery,
+    isComposing,
+    setQuery,
+    updateType,
+    updateCategory,
+    reset,
+    setIsComposing,
+  } = useSearch();
+
+  const { results, loading: resultsLoading } = useSearchResults({
+    query: debouncedQuery,
+    categories,
+  });
+
+  const { updateTab, createTab } = useControlTab();
+
+  const handleSelect = useCallback(
+    (result: Result<Kind>) => {
+      onClose();
+
+      if (result.type === "Tab") {
+        const tab = result as Result<"Tab">;
+        const { id: tabId, windowId } = tab.data;
+        updateTab(tabId, windowId);
+        return;
+      }
+
+      if (
+        ["Bookmark", "History", "Suggestion", "Action.Calculation"].includes(
+          result.type,
+        )
+      ) {
+        createTab(result.url);
+        return;
+      }
+    },
+    [onClose, updateTab, createTab],
+  );
+
+  const handleTab = useCallback(() => {
+    if (!suggestion) return;
+    updateType(suggestion);
+    updateCategory(suggestion);
+  }, [suggestion, updateType, updateCategory]);
+
+  const handleBackspace = useCallback(() => {
+    if (query || (type !== "All" && query)) {
+      return;
+    }
+    reset();
+  }, [query, type, reset]);
+
+  const {
+    selectedIndex,
+    listRef,
+    resetSelectedIndex,
+    handleNavigationKey,
+    handleEnterKey: handleEnter,
+    handleTabKey: handleTab_,
+    handleBackspaceKey: handleBackspace_,
+    handleEscapeKey: handleEscape,
+  } = useSearchKeyboard(
+    {
+      results,
+      isComposing,
+      onSelect: handleSelect,
+      onTab: handleTab,
+      onBackspace: handleBackspace,
+      onEscape: onClose,
+    },
+    {
+      enableVimBindings: false,
+      enableEmacsBindings: false,
+    },
+  );
+
+  const { isShortcutPressed } = useSearchShortcut();
+
+  const handleShortcutKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (isShortcutPressed(e)) {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [isShortcutPressed, onClose],
+  );
+
+  const isSidepanel = variant === "sidepanel";
+
+  return (
+    <Layout className={isSidepanel ? "w-full" : "min-w-[700px] max-w-min"}>
+      <div
+        className={clsx(
+          layoutClassName.bg,
+          layoutClassName.text,
+          layoutClassName.p,
+          layoutClassName.space,
+          !isSidepanel && layoutClassName.border,
+          !isSidepanel && layoutClassName.shadow,
+          isSidepanel && "min-h-screen",
+        )}
+      >
+        <SearchInput
+          className={clsx(searchInputClassName.text, searchInputClassName.bg)}
+          value={query}
+          leftContent={
+            type === "All" ? (
+              <MagnifyingGlassIcon
+                className={clsx(
+                  searchInputClassName.icon.text,
+                  searchInputClassName.icon.size,
+                )}
+              />
+            ) : (
+              <Badge className={searchInputClassName.badge.text} label={type} />
+            )
+          }
+          rightContent={
+            suggestion ? (
+              <div className="flex items-center space-x-1">
+                <div>{t("actions.changeTo")}</div>
+                <div className={searchInputClassName.right.text}>
+                  {suggestion}
+                </div>
+                <SquareBadge
+                  className={clsx("ml-1", searchInputClassName.badge.bg)}
+                >
+                  {t("searchTypes.tab")}
+                </SquareBadge>
+              </div>
+            ) : null
+          }
+          onChange={(e) => {
+            setQuery(e.target.value);
+            resetSelectedIndex();
+          }}
+          onKeyDown={handleShortcutKey}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
+          onArrowUpDownKeyDown={handleNavigationKey}
+          onEnterKeyDown={handleEnter}
+          onTabKeyDown={handleTab_}
+          onEscapeKeyDown={handleEscape}
+          onBackspaceKeyDown={handleBackspace_}
+        />
+        <div className="border-t border-gray-700 border-solid" />
+        <ResultList
+          ref={listRef}
+          items={results}
+          onClick={handleSelect}
+          selectedIndex={selectedIndex}
+        />
+        <div className="border-t border-gray-700 border-solid" />
+        <ResultFooter count={results.length} loading={resultsLoading} />
+      </div>
+    </Layout>
+  );
+}

--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -125,16 +125,18 @@ export default function SearchApp({
   const isSidepanel = variant === "sidepanel";
 
   return (
-    <Layout className={isSidepanel ? "w-full" : "min-w-[700px] max-w-min"}>
+    <Layout
+      className={isSidepanel ? "w-full h-screen" : "min-w-[700px] max-w-min"}
+    >
       <div
         className={clsx(
           layoutClassName.bg,
           layoutClassName.text,
           layoutClassName.p,
-          layoutClassName.space,
+          !isSidepanel && layoutClassName.space,
           !isSidepanel && layoutClassName.border,
           !isSidepanel && layoutClassName.shadow,
-          isSidepanel && "min-h-screen",
+          isSidepanel && "flex flex-col h-full overflow-hidden gap-2",
         )}
       >
         <SearchInput
@@ -186,6 +188,8 @@ export default function SearchApp({
           items={results}
           onClick={handleSelect}
           selectedIndex={selectedIndex}
+          className={isSidepanel ? "flex-1 min-h-0 flex flex-col" : undefined}
+          listClassName={isSidepanel ? "flex-1 overflow-y-auto" : "max-h-56"}
         />
         <div className="border-t border-gray-700 border-solid" />
         <ResultFooter count={results.length} loading={resultsLoading} />

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -69,6 +69,9 @@ export default function useSearchResults(
   // キャッシュ（Ref使用で再レンダリングを防ぐ）
   const cacheRef = useRef<Map<string, CacheEntry<Result<Kind>[]>>>(new Map());
 
+  // リクエストID（古いレスポンスを無視するため）
+  const requestIdRef = useRef(0);
+
   /**
    * 検索結果を取得（内部関数）
    */
@@ -127,11 +130,13 @@ export default function useSearchResults(
    * 検索を実行
    */
   const executeSearch = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setLoadingState("loading");
     setError(null);
 
     try {
       const results = await fetchResults(params.query, params.categories);
+      if (requestId !== requestIdRef.current) return;
       setResults(results);
       setLoadingState("success");
     } catch (err) {
@@ -164,6 +169,7 @@ export default function useSearchResults(
         };
       }
 
+      if (requestId !== requestIdRef.current) return;
       setError(resultError);
       setLoadingState("error");
       console.error("Failed to fetch search results:", err);

--- a/src/features/settings/components/SettingsButton/SettingsButton.tsx
+++ b/src/features/settings/components/SettingsButton/SettingsButton.tsx
@@ -54,13 +54,26 @@ export default function SettingsButton(props: SettingsButtonProps) {
           lastFocusedWindow: true,
         });
         if (tab?.id) {
-          await chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
+          const opened = await chrome.sidePanel
+            .open({ tabId: tab.id })
+            .then(() => true)
+            .catch((e) => {
+              console.error(e);
+              return false;
+            });
+          if (opened) window.close();
         }
-        window.close();
       } else {
         // background 経由で openPopup を呼ぶ（ユーザージェスチャーが伝播する）
-        chrome.runtime.sendMessage({ type: MessageType.SWITCH_VIEW_MODE }, () =>
-          window.close(),
+        chrome.runtime.sendMessage(
+          { type: MessageType.SWITCH_VIEW_MODE },
+          () => {
+            if (chrome.runtime.lastError) {
+              console.error(chrome.runtime.lastError.message);
+              return;
+            }
+            window.close();
+          },
         );
       }
     },
@@ -81,6 +94,7 @@ export default function SettingsButton(props: SettingsButtonProps) {
   return (
     <Menu>
       <MenuButton
+        aria-label={t("settings.open")}
         className={clsx(
           "flex items-center hover:cursor-pointer hover:bg-gray-400 dark:hover:bg-gray-700 group relative space-x-2 p-1 rounded-md focus:outline-none",
           defaultClassName.bg,

--- a/src/features/settings/components/SettingsButton/SettingsButton.tsx
+++ b/src/features/settings/components/SettingsButton/SettingsButton.tsx
@@ -1,0 +1,137 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import Cog6ToothIcon from "@heroicons/react/16/solid/Cog6ToothIcon";
+import ComputerDesktopIcon from "@heroicons/react/16/solid/ComputerDesktopIcon";
+import MoonIcon from "@heroicons/react/16/solid/MoonIcon";
+import RectangleGroupIcon from "@heroicons/react/16/solid/RectangleGroupIcon";
+import Squares2X2Icon from "@heroicons/react/16/solid/Squares2X2Icon";
+import SunIcon from "@heroicons/react/16/solid/SunIcon";
+import { CheckCircleIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+import { useCallback, useContext } from "react";
+import useViewMode from "@/features/settings/hooks/useViewMode";
+import { ThemeContext } from "@/features/theme/context/ThemeProvider";
+import { MessageType } from "@/services/runtime/types";
+import type { ThemeValue, ViewModeValue } from "@/services/storage/types";
+import { defaultClassName } from "@/shared/components/ButtonItem/ButtonItem";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+
+export type SettingsButtonProps = {
+  className?: string;
+};
+
+const ThemeIcon = (props: { theme: ThemeValue; className?: string }) => {
+  switch (props.theme) {
+    case "light":
+      return <SunIcon className={props.className} />;
+    case "dark":
+      return <MoonIcon className={props.className} />;
+    default:
+      return <ComputerDesktopIcon className={props.className} />;
+  }
+};
+
+const ViewModeIcon = (props: { mode: ViewModeValue; className?: string }) => {
+  switch (props.mode) {
+    case "sidepanel":
+      return <RectangleGroupIcon className={props.className} />;
+    default:
+      return <Squares2X2Icon className={props.className} />;
+  }
+};
+
+export default function SettingsButton(props: SettingsButtonProps) {
+  const { t } = useTranslation();
+  const { theme, setTheme } = useContext(ThemeContext);
+  const { viewMode, setViewMode } = useViewMode();
+
+  const handleViewModeChange = useCallback(
+    async (value: ViewModeValue) => {
+      if (value === viewMode) return;
+      setViewMode(value);
+      if (value === "sidepanel") {
+        const [tab] = await chrome.tabs.query({
+          active: true,
+          lastFocusedWindow: true,
+        });
+        if (tab?.id) {
+          await chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
+        }
+        window.close();
+      } else {
+        // background 経由で openPopup を呼ぶ（ユーザージェスチャーが伝播する）
+        chrome.runtime.sendMessage({ type: MessageType.SWITCH_VIEW_MODE }, () =>
+          window.close(),
+        );
+      }
+    },
+    [viewMode, setViewMode],
+  );
+
+  const themes: { value: ThemeValue; label: string }[] = [
+    { value: "light", label: t("theme.light") },
+    { value: "dark", label: t("theme.dark") },
+    { value: "system", label: t("theme.system") },
+  ];
+
+  const modes: { value: ViewModeValue; label: string }[] = [
+    { value: "popup", label: t("viewMode.popup") },
+    { value: "sidepanel", label: t("viewMode.sidepanel") },
+  ];
+
+  return (
+    <Menu>
+      <MenuButton
+        className={clsx(
+          "flex items-center hover:cursor-pointer hover:bg-gray-400 dark:hover:bg-gray-700 group relative space-x-2 p-1 rounded-md focus:outline-none",
+          defaultClassName.bg,
+          props.className,
+        )}
+      >
+        <Cog6ToothIcon className="size-5" />
+      </MenuButton>
+      <MenuItems
+        transition
+        anchor="top start"
+        className="transition duration-200 ease-in-out bg-white border-2 border-gray-600 rounded-lg shadow-lg focus:outline-none dark:bg-gray-800 [--anchor-gap:--spacing(1)] data-[closed]:opacity-0 data-[closed]:scale-95"
+      >
+        <div className="px-3 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          {t("settings.theme")}
+        </div>
+        {themes.map((item) => (
+          <MenuItem
+            as="button"
+            disabled={theme === item.value}
+            key={item.value}
+            className="flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300"
+            onClick={() => setTheme(item.value)}
+          >
+            <ThemeIcon theme={item.value} className="size-5" />
+            <div className="min-w-16">{item.label}</div>
+            {theme === item.value && (
+              <CheckCircleIcon className="flex-none ml-auto size-5" />
+            )}
+          </MenuItem>
+        ))}
+        <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
+        <div className="px-3 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          {t("settings.viewMode")}
+        </div>
+        {modes.map((item) => (
+          <MenuItem
+            as="button"
+            disabled={viewMode === item.value}
+            key={item.value}
+            className="flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300"
+            onClick={() => handleViewModeChange(item.value)}
+          >
+            <ViewModeIcon mode={item.value} className="size-5" />
+            <div className="min-w-20">{item.label}</div>
+            {viewMode === item.value && (
+              <CheckCircleIcon className="flex-none ml-auto size-5" />
+            )}
+          </MenuItem>
+        ))}
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/src/features/settings/components/ViewModeSelect/ViewModeSelect.tsx
+++ b/src/features/settings/components/ViewModeSelect/ViewModeSelect.tsx
@@ -1,0 +1,67 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import RectangleGroupIcon from "@heroicons/react/16/solid/RectangleGroupIcon";
+import Squares2X2Icon from "@heroicons/react/16/solid/Squares2X2Icon";
+import { CheckCircleIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+import useViewMode from "@/features/settings/hooks/useViewMode";
+import type { ViewModeValue } from "@/services/storage/types";
+import { defaultClassName } from "@/shared/components/ButtonItem/ButtonItem";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+
+export type ViewModeSelectProps = {
+  className?: string;
+};
+
+const ViewModeIcon = (props: { mode: ViewModeValue; className?: string }) => {
+  switch (props.mode) {
+    case "sidepanel":
+      return <RectangleGroupIcon className={props.className} />;
+    default:
+      return <Squares2X2Icon className={props.className} />;
+  }
+};
+
+export default function ViewModeSelect(props: ViewModeSelectProps) {
+  const { t } = useTranslation();
+  const { viewMode, setViewMode } = useViewMode();
+
+  const modes: { value: ViewModeValue; label: string }[] = [
+    { value: "popup", label: t("viewMode.popup") },
+    { value: "sidepanel", label: t("viewMode.sidepanel") },
+  ];
+
+  return (
+    <Menu>
+      <MenuButton
+        className={clsx(
+          "flex items-center hover:cursor-pointer hover:bg-gray-400 dark:hover:bg-gray-700 group relative space-x-2 p-1 rounded-md focus:outline-none",
+          defaultClassName.bg,
+          props.className,
+        )}
+      >
+        <ViewModeIcon mode={viewMode} className="size-5" />
+      </MenuButton>
+      <MenuItems
+        transition
+        anchor="top start"
+        className="transition duration-200 ease-in-out bg-white border-2 border-gray-600 rounded-lg shadow-lg focus:outline-none dark:bg-gray-800 [--anchor-gap:--spacing(1)] data-[closed]:opacity-0 data-[closed]:scale-95"
+      >
+        {modes.map((m) => (
+          <MenuItem
+            as="button"
+            disabled={viewMode === m.value}
+            key={m.value}
+            className="flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300"
+            onClick={() => setViewMode(m.value)}
+          >
+            <ViewModeIcon mode={m.value} className="size-5" />
+            <div className="min-w-20">{m.label}</div>
+            {viewMode === m.value && (
+              <CheckCircleIcon className="flex-none ml-auto size-5" />
+            )}
+          </MenuItem>
+        ))}
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/src/features/settings/components/ViewModeSelect/ViewModeSelect.tsx
+++ b/src/features/settings/components/ViewModeSelect/ViewModeSelect.tsx
@@ -3,6 +3,7 @@ import RectangleGroupIcon from "@heroicons/react/16/solid/RectangleGroupIcon";
 import Squares2X2Icon from "@heroicons/react/16/solid/Squares2X2Icon";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import clsx from "clsx";
+import { useCallback } from "react";
 import useViewMode from "@/features/settings/hooks/useViewMode";
 import type { ViewModeValue } from "@/services/storage/types";
 import { defaultClassName } from "@/shared/components/ButtonItem/ButtonItem";
@@ -25,6 +26,23 @@ export default function ViewModeSelect(props: ViewModeSelectProps) {
   const { t } = useTranslation();
   const { viewMode, setViewMode } = useViewMode();
 
+  const handleChange = useCallback(
+    async (value: ViewModeValue) => {
+      if (value === viewMode) return;
+      setViewMode(value);
+      if (value === "sidepanel") {
+        const [tab] = await chrome.tabs.query({
+          active: true,
+          lastFocusedWindow: true,
+        });
+        if (tab?.id) {
+          await chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
+        }
+      }
+    },
+    [viewMode, setViewMode],
+  );
+
   const modes: { value: ViewModeValue; label: string }[] = [
     { value: "popup", label: t("viewMode.popup") },
     { value: "sidepanel", label: t("viewMode.sidepanel") },
@@ -33,6 +51,7 @@ export default function ViewModeSelect(props: ViewModeSelectProps) {
   return (
     <Menu>
       <MenuButton
+        aria-label={t("settings.viewMode")}
         className={clsx(
           "flex items-center hover:cursor-pointer hover:bg-gray-400 dark:hover:bg-gray-700 group relative space-x-2 p-1 rounded-md focus:outline-none",
           defaultClassName.bg,
@@ -52,7 +71,7 @@ export default function ViewModeSelect(props: ViewModeSelectProps) {
             disabled={viewMode === m.value}
             key={m.value}
             className="flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300"
-            onClick={() => setViewMode(m.value)}
+            onClick={() => handleChange(m.value)}
           >
             <ViewModeIcon mode={m.value} className="size-5" />
             <div className="min-w-20">{m.label}</div>

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -1,0 +1,72 @@
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  getDefaultViewMode,
+  SyncStorageKey,
+  storageService,
+  type ViewModeValue,
+} from "@/services/storage";
+
+const listeners = new Set<() => void>();
+
+let snapshot: ViewModeValue = getDefaultViewMode();
+
+const notify = () => {
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+const updateSnapshot = (viewMode: ViewModeValue) => {
+  snapshot = viewMode;
+  notify();
+};
+
+const subscribeExternalChanges = () =>
+  storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
+    if (newViewMode) {
+      updateSnapshot(newViewMode);
+    }
+  });
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = () => snapshot;
+
+const hydrateViewMode = async () => {
+  try {
+    const stored = await storageService.getViewMode();
+    updateSnapshot(stored ?? getDefaultViewMode());
+  } catch (error) {
+    console.error("Failed to hydrate viewMode", error);
+    updateSnapshot(getDefaultViewMode());
+  }
+};
+
+void hydrateViewMode();
+
+export default function useViewMode() {
+  const viewMode = useSyncExternalStore(
+    (listener) => {
+      const unsubscribeInternal = subscribe(listener);
+      const unsubscribeExternal = subscribeExternalChanges();
+      return () => {
+        unsubscribeInternal();
+        unsubscribeExternal();
+      };
+    },
+    getSnapshot,
+    getSnapshot,
+  );
+
+  const setViewMode = useCallback((value: ViewModeValue) => {
+    updateSnapshot(value);
+    storageService.setViewMode(value).catch((error) => {
+      console.error("Failed to persist viewMode", error);
+    });
+  }, []);
+
+  return { viewMode, setViewMode };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,15 @@
     "dark": "Dark",
     "system": "System"
   },
+  "viewMode": {
+    "popup": "Popup",
+    "sidepanel": "Side Panel"
+  },
+  "settings": {
+    "title": "Settings",
+    "theme": "Theme",
+    "viewMode": "View Mode"
+  },
   "language": {
     "en": "English",
     "ja": "日本語"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,7 +32,8 @@
   "settings": {
     "title": "Settings",
     "theme": "Theme",
-    "viewMode": "View Mode"
+    "viewMode": "View Mode",
+    "open": "Open settings"
   },
   "language": {
     "en": "English",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -32,7 +32,8 @@
   "settings": {
     "title": "設定",
     "theme": "テーマ",
-    "viewMode": "表示モード"
+    "viewMode": "表示モード",
+    "open": "設定を開く"
   },
   "language": {
     "en": "English",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -25,6 +25,15 @@
     "dark": "ダーク",
     "system": "システム"
   },
+  "viewMode": {
+    "popup": "ポップアップ",
+    "sidepanel": "サイドパネル"
+  },
+  "settings": {
+    "title": "設定",
+    "theme": "テーマ",
+    "viewMode": "表示モード"
+  },
   "language": {
     "en": "English",
     "ja": "日本語"

--- a/src/services/bookmark/service.ts
+++ b/src/services/bookmark/service.ts
@@ -16,12 +16,24 @@ export interface BookmarkService {
 }
 
 const queryBookmarks = async ({
-  query: _,
+  query,
+  option,
 }: Type.QueryBookmarksRequest): Promise<Type.Bookmark[]> => {
   try {
-    const response = await chrome.bookmarks.getTree();
+    const count = option?.count;
+    let nodes: chrome.bookmarks.BookmarkTreeNode[];
 
-    const bookmarks = filterValidBookmarks(response).map(convertBookmark);
+    if (query) {
+      nodes = await chrome.bookmarks.search({ query });
+    } else {
+      const tree = await chrome.bookmarks.getTree();
+      nodes = filterValidBookmarks(tree);
+    }
+
+    const bookmarks = nodes
+      .filter((n) => !!n.url)
+      .slice(0, count)
+      .map(convertBookmark);
 
     return bookmarks;
   } catch (error) {

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -26,5 +26,4 @@ export enum MessageType {
 
 export interface SwitchViewModeRequest {
   type: MessageType.SWITCH_VIEW_MODE;
-  viewMode: "popup" | "sidepanel";
 }

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -21,4 +21,10 @@ export enum MessageType {
   UPDATE_TAB = "UPDATE_TAB",
   REMOVE_TAB = "REMOVE_TAB",
   QUERY_RESULT = "QUERY_RESULT",
+  SWITCH_VIEW_MODE = "SWITCH_VIEW_MODE",
+}
+
+export interface SwitchViewModeRequest {
+  type: MessageType.SWITCH_VIEW_MODE;
+  viewMode: "popup" | "sidepanel";
 }

--- a/src/services/storage/helper.ts
+++ b/src/services/storage/helper.ts
@@ -2,7 +2,12 @@
  * Storage Helper - Chrome storage関連のヘルパー関数
  */
 
-import type { SyncStorage, SyncStorageKey, ThemeValue } from "./types";
+import type {
+  SyncStorage,
+  SyncStorageKey,
+  ThemeValue,
+  ViewModeValue,
+} from "./types";
 
 /**
  * Promise化されたchrome.storage.sync.get
@@ -48,6 +53,18 @@ export const getDefaultTheme = (): ThemeValue => "system";
  */
 export const isValidTheme = (value: unknown): value is ThemeValue => {
   return ["light", "dark", "system"].includes(value as string);
+};
+
+/**
+ * デフォルト表示モード値を取得
+ */
+export const getDefaultViewMode = (): ViewModeValue => "popup";
+
+/**
+ * 表示モード値のバリデーション
+ */
+export const isValidViewMode = (value: unknown): value is ViewModeValue => {
+  return ["popup", "sidepanel"].includes(value as string);
 };
 
 /**

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -3,7 +3,12 @@
  * 責任: Chrome storage sync APIの抽象化を担当
  */
 
-import { chromeStorageGet, chromeStorageSet, getDefaultTheme } from "./helper";
+import {
+  chromeStorageGet,
+  chromeStorageSet,
+  getDefaultTheme,
+  getDefaultViewMode,
+} from "./helper";
 import type * as Type from "./types";
 import { SyncStorageKey } from "./types";
 
@@ -21,6 +26,8 @@ export interface StorageService {
   ) => () => void;
   getTheme: () => Promise<Type.ThemeValue>;
   setTheme: (request: Type.SetThemeRequest) => Promise<boolean>;
+  getViewMode: () => Promise<Type.ViewModeValue>;
+  setViewMode: (viewMode: Type.ViewModeValue) => Promise<boolean>;
 }
 
 // サービス実装
@@ -84,6 +91,25 @@ const setTheme = async ({ theme }: Type.SetThemeRequest): Promise<boolean> => {
   }
 };
 
+const getViewMode = async (): Promise<Type.ViewModeValue> => {
+  try {
+    const viewMode = await chromeStorageGet(SyncStorageKey.ViewMode);
+    return viewMode || getDefaultViewMode();
+  } catch (error) {
+    console.error("Failed to get viewMode:", error);
+    return getDefaultViewMode();
+  }
+};
+
+const setViewMode = async (viewMode: Type.ViewModeValue): Promise<boolean> => {
+  try {
+    return await chromeStorageSet(SyncStorageKey.ViewMode, viewMode);
+  } catch (error) {
+    console.error("Failed to set viewMode:", error);
+    throw new Error("表示モードの保存に失敗しました");
+  }
+};
+
 // サービスオブジェクトのエクスポート
 export const storageService: StorageService = {
   get: getStorage,
@@ -91,6 +117,8 @@ export const storageService: StorageService = {
   subscribe: subscribeStorage,
   getTheme,
   setTheme,
+  getViewMode,
+  setViewMode,
 };
 
 // デフォルトエクスポート

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -8,6 +8,7 @@ import {
   chromeStorageSet,
   getDefaultTheme,
   getDefaultViewMode,
+  isValidViewMode,
 } from "./helper";
 import type * as Type from "./types";
 import { SyncStorageKey } from "./types";
@@ -94,7 +95,7 @@ const setTheme = async ({ theme }: Type.SetThemeRequest): Promise<boolean> => {
 const getViewMode = async (): Promise<Type.ViewModeValue> => {
   try {
     const viewMode = await chromeStorageGet(SyncStorageKey.ViewMode);
-    return viewMode || getDefaultViewMode();
+    return isValidViewMode(viewMode) ? viewMode : getDefaultViewMode();
   } catch (error) {
     console.error("Failed to get viewMode:", error);
     return getDefaultViewMode();

--- a/src/services/storage/types.ts
+++ b/src/services/storage/types.ts
@@ -4,12 +4,15 @@
 
 export enum SyncStorageKey {
   Theme = "theme",
+  ViewMode = "viewMode",
 }
 
 export type ThemeValue = "light" | "dark" | "system";
+export type ViewModeValue = "popup" | "sidepanel";
 
 export interface SyncStorage {
   [SyncStorageKey.Theme]: ThemeValue;
+  [SyncStorageKey.ViewMode]: ViewModeValue;
 }
 
 // リクエスト型定義

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["chrome"]
   }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   webExt: {
     disabled: true,
   },
+  browser: "chrome",
   modules: ["@wxt-dev/module-react", "@wxt-dev/auto-icons", "@wxt-dev/i18n/module"],
   vite: () => ({
     plugins: [tailwindcss()],
@@ -18,7 +19,7 @@ export default defineConfig({
     current_locale: "en",
     description: "Search your bookmarks and history",
     version: "1.5.2",
-    permissions: ["tabs", "history", "activeTab", "bookmarks", "storage"],
+    permissions: ["tabs", "history", "activeTab", "bookmarks", "storage", "sidePanel"],
     commands: {
       OPEN_POPUP: {
         suggested_key: {


### PR DESCRIPTION
- Add functionality to switch between popup and side panel view modes.
- Create a settings page to manage theme and view mode preferences.
- Update storage service to handle view mode state.
- Integrate side panel behavior with storage service for dynamic updates.
- Refactor search app to support both popup and side panel variants.
- Enhance user experience with settings button for theme and view mode selection.
- Localize new settings and view mode options in English and Japanese.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page and menu to manage Theme and View Mode (popup / side panel)
  * Side Panel mode and dedicated sidepanel entrypoint for the search UI
  * New unified SearchApp component usable in popup or sidepanel

* **Bug Fixes / Improvements**
  * Background and messaging now respect and sync view mode when opening the UI
  * Search results ignore stale responses to prevent flicker

* **Localization**
  * Added view mode and settings translations (en, ja)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->