### PR TITLE
fix: resolve sidepanel not opening via keyboard shortcut

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -6,6 +6,10 @@ import { routeCommand, routeMessage } from "./router";
 // await の前に呼び出せるよう viewMode をキャッシュしておく
 let cachedViewMode: ViewModeValue = "popup";
 
+// サイドパネルの開閉状態をポート接続で追跡する
+// ポートが存在する = サイドパネルが開いている
+let sidePanelPort: chrome.runtime.Port | null = null;
+
 export default defineBackground(() => {
   const updateViewMode = (viewMode: ViewModeValue) => {
     cachedViewMode = viewMode;
@@ -22,11 +26,20 @@ export default defineBackground(() => {
     updateViewMode(viewMode ?? "popup");
   });
 
+  // サイドパネルの開閉状態をポート接続で追跡する
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port.name !== "sidepanel") return;
+    sidePanelPort = port;
+    port.onDisconnect.addListener(() => {
+      sidePanelPort = null;
+    });
+  });
+
   /**
    * @description コマンドのルーティング
    */
   chrome.commands.onCommand.addListener((command, tab) => {
-    routeCommand(command, tab, cachedViewMode);
+    routeCommand(command, tab, cachedViewMode, sidePanelPort);
   });
 
   /**

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,17 +1,24 @@
 import { storageService } from "@/services/storage";
-import { SyncStorageKey } from "@/services/storage/types";
+import { SyncStorageKey, type ViewModeValue } from "@/services/storage/types";
 import { routeCommand, routeMessage } from "./router";
+
+// chrome.sidePanel.open() はユーザージェスチャートークンが必要なため、
+// await の前に呼び出せるよう viewMode をキャッシュしておく
+let cachedViewMode: ViewModeValue = "popup";
 
 export default defineBackground(() => {
   // サイドパネルの初期化
   storageService.getViewMode().then((viewMode) => {
+    cachedViewMode = viewMode;
     chrome.sidePanel
       .setPanelBehavior({ openPanelOnActionClick: viewMode === "sidepanel" })
       .catch(console.error);
   });
 
-  // viewMode変更時にサイドパネルの動作を更新
+  // viewMode変更時にキャッシュとサイドパネルの動作を更新
   storageService.subscribe(SyncStorageKey.ViewMode, (viewMode) => {
+    if (viewMode === undefined) return;
+    cachedViewMode = viewMode;
     chrome.sidePanel
       .setPanelBehavior({ openPanelOnActionClick: viewMode === "sidepanel" })
       .catch(console.error);
@@ -21,7 +28,7 @@ export default defineBackground(() => {
    * @description コマンドのルーティング
    */
   chrome.commands.onCommand.addListener((command, tab) => {
-    routeCommand(command, tab);
+    routeCommand(command, tab, cachedViewMode);
   });
 
   /**

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -7,21 +7,19 @@ import { routeCommand, routeMessage } from "./router";
 let cachedViewMode: ViewModeValue = "popup";
 
 export default defineBackground(() => {
-  // サイドパネルの初期化
-  storageService.getViewMode().then((viewMode) => {
+  const updateViewMode = (viewMode: ViewModeValue) => {
     cachedViewMode = viewMode;
     chrome.sidePanel
       .setPanelBehavior({ openPanelOnActionClick: viewMode === "sidepanel" })
       .catch(console.error);
-  });
+  };
+
+  // サイドパネルの初期化
+  storageService.getViewMode().then(updateViewMode);
 
   // viewMode変更時にキャッシュとサイドパネルの動作を更新
   storageService.subscribe(SyncStorageKey.ViewMode, (viewMode) => {
-    if (viewMode === undefined) return;
-    cachedViewMode = viewMode;
-    chrome.sidePanel
-      .setPanelBehavior({ openPanelOnActionClick: viewMode === "sidepanel" })
-      .catch(console.error);
+    updateViewMode(viewMode ?? "popup");
   });
 
   /**

--- a/src/entrypoints/background/router/command.ts
+++ b/src/entrypoints/background/router/command.ts
@@ -1,13 +1,18 @@
 import { contentService } from "@/services/content";
 import { MessageType } from "@/services/runtime/types";
-import { storageService } from "@/services/storage";
+import type { ViewModeValue } from "@/services/storage/types";
 
-export const routeCommand = async (command: string, tab: chrome.tabs.Tab) => {
+export const routeCommand = (
+  command: string,
+  tab: chrome.tabs.Tab,
+  viewMode: ViewModeValue,
+) => {
   switch (command) {
     case MessageType.OPEN_POPUP: {
-      const viewMode = await storageService.getViewMode();
+      // chrome.sidePanel.open() はユーザージェスチャートークンが必要なため、
+      // await より前に同期的に呼び出す
       if (viewMode === "sidepanel" && tab.id) {
-        await chrome.sidePanel.open({ tabId: tab.id });
+        chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
       } else {
         contentService.open({}).then((res) => {
           if (!res.success) {

--- a/src/entrypoints/background/router/command.ts
+++ b/src/entrypoints/background/router/command.ts
@@ -2,16 +2,23 @@ import { contentService } from "@/services/content";
 import { MessageType } from "@/services/runtime/types";
 import type { ViewModeValue } from "@/services/storage/types";
 
+/**
+ * コマンドに基づいて適切なアクション（ポップアップまたはサイドパネル）を呼び出します。
+ *
+ * @param command コマンド名
+ * @param tab 実行時のタブ情報（コンテキストによっては undefined になる場合あり）
+ * @param viewMode 現在の表示モード
+ */
 export const routeCommand = (
   command: string,
-  tab: chrome.tabs.Tab,
+  tab: chrome.tabs.Tab | undefined,
   viewMode: ViewModeValue,
 ) => {
   switch (command) {
     case MessageType.OPEN_POPUP: {
       // chrome.sidePanel.open() はユーザージェスチャートークンが必要なため、
       // await より前に同期的に呼び出す
-      if (viewMode === "sidepanel" && tab.id) {
+      if (viewMode === "sidepanel" && tab?.id !== undefined) {
         chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
       } else {
         contentService.open({}).then((res) => {

--- a/src/entrypoints/background/router/command.ts
+++ b/src/entrypoints/background/router/command.ts
@@ -8,18 +8,26 @@ import type { ViewModeValue } from "@/services/storage/types";
  * @param command コマンド名
  * @param tab 実行時のタブ情報（コンテキストによっては undefined になる場合あり）
  * @param viewMode 現在の表示モード
+ * @param sidePanelPort サイドパネルとのポート接続（開いている場合のみ存在）
  */
 export const routeCommand = (
   command: string,
   tab: chrome.tabs.Tab | undefined,
   viewMode: ViewModeValue,
+  sidePanelPort: chrome.runtime.Port | null,
 ) => {
   switch (command) {
     case MessageType.OPEN_POPUP: {
-      // chrome.sidePanel.open() はユーザージェスチャートークンが必要なため、
-      // await より前に同期的に呼び出す
-      if (viewMode === "sidepanel" && tab?.id !== undefined) {
-        chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
+      if (viewMode === "sidepanel") {
+        if (sidePanelPort !== null) {
+          // サイドパネルが開いている → 閉じる
+          sidePanelPort.postMessage({ type: MessageType.CLOSE_SIDEPANEL });
+        } else if (tab?.id !== undefined) {
+          // サイドパネルが閉じている → 開く
+          // chrome.sidePanel.open() はユーザージェスチャートークンが必要なため、
+          // await より前に同期的に呼び出す
+          chrome.sidePanel.open({ tabId: tab.id }).catch(console.error);
+        }
       } else {
         contentService.open({}).then((res) => {
           if (!res.success) {

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -1,6 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { MessageType } from "@/services/runtime/types";
 import App from "./App";
+
+// バックグラウンドにサイドパネルの開閉状態を通知するためのポート接続
+// ポート切断 = サイドパネルが閉じられたことをバックグラウンドが検知できる
+const port = chrome.runtime.connect({ name: "sidepanel" });
+
+port.onMessage.addListener((message) => {
+  if (message.type === MessageType.CLOSE_SIDEPANEL) {
+    window.close();
+  }
+});
 
 const rootElement =
   document.getElementById("root") ??

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -16,6 +16,7 @@ export interface QueryTabsRequest {
 
 export enum MessageType {
   CLOSE_POPUP = "CLOSE_POPUP",
+  CLOSE_SIDEPANEL = "CLOSE_SIDEPANEL",
   OPEN_POPUP = "OPEN_POPUP",
   CREATE_TAB = "CREATE_TAB",
   UPDATE_TAB = "UPDATE_TAB",


### PR DESCRIPTION
## Summary

- `cachedViewMode` をモジュールスコープ変数として `background/index.ts` に追加し、起動時・変更時に更新
- `routeCommand` を `async` から同期関数に変更し、`viewMode` を引数として受け取るよう修正
- `chrome.sidePanel.open()` を `await` の前（同期的）に呼び出すことでユーザージェスチャートークンの失効を防止

Closes #140

## 原因

`chrome.sidePanel.open()` は `chrome.action.openPopup()` と同様にユーザージェスチャートークンが必要。旧実装では `await storageService.getViewMode()` の後に呼んでいたため、トークンが失効して無音で失敗していた。

## Test plan

- [x] viewMode を `sidepanel` に設定した状態で Cmd+T / Ctrl+T を押すとサイドパネルが開くこと
- [x] viewMode を `popup` に設定した状態で Cmd+T / Ctrl+T を押すとポップアップが開くこと
- [x] `pnpm compile` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR #141: キーボードショートカットでサイドパネルが開かない問題を修正

### 概要

このPRは、viewModeが`sidepanel`に設定されている場合、キーボードショートカット（Cmd+T / Ctrl+T）でサイドパネルが開かない問題を修正します。根本原因は`chrome.sidePanel.open()`がユーザージェスチャートークンを必要とするのに対し、`storageService.getViewMode()`の`await`によってトークンが失効していたことです。

### 変更内容

**src/entrypoints/background/index.ts**
- モジュールスコープに`cachedViewMode`変数を追加し、初期値を`"popup"`に設定
- アプリケーション起動時に`storageService.getViewMode()`の結果で`cachedViewMode`を初期化
- `storageService.subscribe()`でviewModeの変更を監視し、キャッシュを常に最新に保つ
- `chrome.commands.onCommand`のリスナーで`routeCommand`に`cachedViewMode`を引数として渡すよう更新

**src/entrypoints/background/router/command.ts**
- `routeCommand`を`async`から同期関数に変更
- `viewMode: ViewModeValue`を関数の引数として追加
- `viewMode === "sidepanel"`の場合、`chrome.sidePanel.open()`を同期的に呼び出し（awaitなし）
- エラーハンドリングは`.catch(console.error)`で実装
- コメントを追加してユーザージェスチャートークンの要件を説明

### 技術的詳細

**修正の根拠:**
`chrome.sidePanel.open()`や`chrome.action.openPopup()`といったAPI呼び出しはユーザージェスチャートークンが必要です。前の実装では、非同期の`storageService.getViewMode()`をawaitしてからこれらのAPI呼び出しを実行していたため、トークンが失効してサイレント失敗していました。viewModeをモジュールレベルでキャッシュすることで、ユーザージェスチャー内で同期的にAPI呼び出しを実行できるようになります。

### テスト計画

- ✅ viewMode = `sidepanel`のとき、Cmd+T / Ctrl+Tでサイドパネルが開く
- ✅ viewMode = `popup`のとき、Cmd+T / Ctrl+Tでポップアップが開く
- ✅ `pnpm compile`に成功する

### Issue関連

Closes #140

<!-- end of auto-generated comment: release notes by coderabbit.ai -->