### PR TITLE
fix: handle MV3 Service Worker restart in sendMessage

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -26,13 +26,17 @@ export default defineBackground(() => {
     updateViewMode(viewMode ?? "popup");
   });
 
-  // サイドパネルの開閉状態をポート接続で追跡する
+  // ポート接続の処理:
+  // - "sidepanel": サイドパネルの開閉状態を追跡する
+  // - "keepalive": ポップアップからの SW 生存維持用（接続を受け入れるだけでよい）
+  // いずれのポートも接続が続く限り MV3 Service Worker を生存させる
   chrome.runtime.onConnect.addListener((port) => {
-    if (port.name !== "sidepanel") return;
-    sidePanelPort = port;
-    port.onDisconnect.addListener(() => {
-      sidePanelPort = null;
-    });
+    if (port.name === "sidepanel") {
+      sidePanelPort = port;
+      port.onDisconnect.addListener(() => {
+        sidePanelPort = null;
+      });
+    }
   });
 
   /**

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -12,6 +12,24 @@ chrome.runtime.onMessage.addListener((message) => {
   }
 });
 
+// MV3 Service Worker はアイドル時に停止されるため、ポート接続で生存を維持する。
+// ポップアップが開いている間は SW を生かし続け、メッセージ送信の失敗を防ぐ。
+const KEEPALIVE_INTERVAL_MS = 25000;
+
+function connectKeepalivePort(): void {
+  const port = chrome.runtime.connect({ name: "keepalive" });
+  const interval = setInterval(
+    () => port.postMessage({ type: "PING" }),
+    KEEPALIVE_INTERVAL_MS,
+  );
+  port.onDisconnect.addListener(() => {
+    clearInterval(interval);
+    connectKeepalivePort();
+  });
+}
+
+connectKeepalivePort();
+
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { contentService } from "@/services/content";
+import { runtimeService } from "@/services/runtime";
 import App from "./App";
 
 const rootElement =
@@ -12,23 +13,8 @@ chrome.runtime.onMessage.addListener((message) => {
   }
 });
 
-// MV3 Service Worker はアイドル時に停止されるため、ポート接続で生存を維持する。
-// ポップアップが開いている間は SW を生かし続け、メッセージ送信の失敗を防ぐ。
-const KEEPALIVE_INTERVAL_MS = 25000;
-
-function connectKeepalivePort(): void {
-  const port = chrome.runtime.connect({ name: "keepalive" });
-  const interval = setInterval(
-    () => port.postMessage({ type: "PING" }),
-    KEEPALIVE_INTERVAL_MS,
-  );
-  port.onDisconnect.addListener(() => {
-    clearInterval(interval);
-    connectKeepalivePort();
-  });
-}
-
-connectKeepalivePort();
+// MV3 Service Worker のアイドル停止を防ぐ永続ポート接続を確立する
+runtimeService.connectPort("keepalive");
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -1,33 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { MessageType } from "@/services/runtime/types";
+import { MessageType, runtimeService } from "@/services/runtime";
 import App from "./App";
 
-// バックグラウンドにサイドパネルの開閉状態を通知するためのポート接続。
-// ポート切断 = サイドパネルが閉じられたことをバックグラウンドが検知できる。
-// 25 秒ごとの ping により MV3 Service Worker の停止も防ぐ。
-const KEEPALIVE_INTERVAL_MS = 25000;
-
-function connectSidePanelPort(): void {
-  const port = chrome.runtime.connect({ name: "sidepanel" });
-  const interval = setInterval(
-    () => port.postMessage({ type: "PING" }),
-    KEEPALIVE_INTERVAL_MS,
-  );
-
-  port.onMessage.addListener((message) => {
-    if (message.type === MessageType.CLOSE_SIDEPANEL) {
-      window.close();
-    }
-  });
-
-  port.onDisconnect.addListener(() => {
-    clearInterval(interval);
-    connectSidePanelPort();
-  });
-}
-
-connectSidePanelPort();
+// バックグラウンドにサイドパネルの開閉状態を通知しつつ、
+// MV3 Service Worker のアイドル停止を防ぐ永続ポート接続を確立する
+runtimeService.connectPort("sidepanel", (message) => {
+  if ((message as { type: string }).type === MessageType.CLOSE_SIDEPANEL) {
+    window.close();
+  }
+});
 
 const rootElement =
   document.getElementById("root") ??

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -3,15 +3,31 @@ import ReactDOM from "react-dom/client";
 import { MessageType } from "@/services/runtime/types";
 import App from "./App";
 
-// バックグラウンドにサイドパネルの開閉状態を通知するためのポート接続
-// ポート切断 = サイドパネルが閉じられたことをバックグラウンドが検知できる
-const port = chrome.runtime.connect({ name: "sidepanel" });
+// バックグラウンドにサイドパネルの開閉状態を通知するためのポート接続。
+// ポート切断 = サイドパネルが閉じられたことをバックグラウンドが検知できる。
+// 25 秒ごとの ping により MV3 Service Worker の停止も防ぐ。
+const KEEPALIVE_INTERVAL_MS = 25000;
 
-port.onMessage.addListener((message) => {
-  if (message.type === MessageType.CLOSE_SIDEPANEL) {
-    window.close();
-  }
-});
+function connectSidePanelPort(): void {
+  const port = chrome.runtime.connect({ name: "sidepanel" });
+  const interval = setInterval(
+    () => port.postMessage({ type: "PING" }),
+    KEEPALIVE_INTERVAL_MS,
+  );
+
+  port.onMessage.addListener((message) => {
+    if (message.type === MessageType.CLOSE_SIDEPANEL) {
+      window.close();
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    clearInterval(interval);
+    connectSidePanelPort();
+  });
+}
+
+connectSidePanelPort();
 
 const rootElement =
   document.getElementById("root") ??

--- a/src/services/runtime/constants.ts
+++ b/src/services/runtime/constants.ts
@@ -1,0 +1,2 @@
+// SW の30秒アイドルタイマーをリセットするための ping 間隔
+export const KEEPALIVE_INTERVAL_MS = 25000;

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -9,6 +9,7 @@ import type {
   RemoveTabRequest,
   UpdateTabRequest,
 } from "@/services/tab/types";
+import { KEEPALIVE_INTERVAL_MS } from "./constants";
 import { RuntimeServiceError } from "./error";
 import { MessageType, type RuntimeResponse } from "./types";
 
@@ -28,9 +29,6 @@ export interface RuntimeService {
    */
   connectPort: (name: string, onMessage?: (message: unknown) => void) => void;
 }
-
-// SW の30秒アイドルタイマーをリセットするための ping 間隔
-const KEEPALIVE_INTERVAL_MS = 25000;
 
 function connectPort(
   name: string,

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -12,38 +12,6 @@ import type {
 import { RuntimeServiceError } from "./error";
 import { MessageType, type RuntimeResponse } from "./types";
 
-/**
- * MV3 Service Worker が停止中に sendMessage すると
- * "Could not establish connection. Receiving end does not exist." が発生する。
- * この失敗自体が SW を起動するトリガーになるため、
- * 起動完了を待ってから 1 回だけリトライする。
- */
-const SW_RESTART_DELAY_MS = 500;
-
-function isConnectionError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.message.includes("Could not establish connection") ||
-      error.message.includes("Receiving end does not exist"))
-  );
-}
-
-async function sendRuntimeMessage<T>(message: object): Promise<T> {
-  try {
-    return (await chrome.runtime.sendMessage(message)) as T;
-  } catch (error) {
-    if (isConnectionError(error)) {
-      // SW が停止していた場合、上記の sendMessage が起動トリガーになる。
-      // 初期化完了を待ってからリトライする。
-      await new Promise<void>((resolve) =>
-        setTimeout(resolve, SW_RESTART_DELAY_MS),
-      );
-      return (await chrome.runtime.sendMessage(message)) as T;
-    }
-    throw error;
-  }
-}
-
 export interface RuntimeService {
   createTab: (request: CreateTabRequest) => Promise<void>;
   updateTab: (request: UpdateTabRequest) => Promise<void>;
@@ -55,7 +23,7 @@ export interface RuntimeService {
 
 const createTab = async ({ url }: CreateTabRequest): Promise<void> => {
   try {
-    await sendRuntimeMessage({
+    await chrome.runtime.sendMessage({
       type: MessageType.CREATE_TAB,
       url,
     });
@@ -77,7 +45,7 @@ const updateTab = async ({
   windowId,
 }: UpdateTabRequest): Promise<void> => {
   try {
-    await sendRuntimeMessage({
+    await chrome.runtime.sendMessage({
       type: MessageType.UPDATE_TAB,
       tabId,
       windowId,
@@ -97,7 +65,7 @@ const updateTab = async ({
 
 const removeTab = async ({ tabId }: RemoveTabRequest): Promise<void> => {
   try {
-    await sendRuntimeMessage({
+    await chrome.runtime.sendMessage({
       type: MessageType.REMOVE_TAB,
       tabId,
     });
@@ -118,10 +86,10 @@ const queryResults = async ({
   filters,
 }: QueryResultsRequest): Promise<Result<Kind>[]> => {
   try {
-    const response = await sendRuntimeMessage<RuntimeResponse<Result<Kind>[]>>({
+    const response = (await chrome.runtime.sendMessage({
       type: MessageType.QUERY_RESULT,
       filters,
-    });
+    })) as RuntimeResponse<Result<Kind>[]>;
 
     return response.result;
   } catch (error) {
@@ -139,7 +107,7 @@ const queryResults = async ({
 
 const openContent = async (): Promise<void> => {
   try {
-    await sendRuntimeMessage({ type: MessageType.OPEN_POPUP });
+    await chrome.runtime.sendMessage({ type: MessageType.OPEN_POPUP });
   } catch (error) {
     console.error(`Failed to open Content:`, error);
     // WARN: 処理が失敗した場合はPopup のサービスを表示する
@@ -150,7 +118,7 @@ const openContent = async (): Promise<void> => {
 
 const closeContent = async (): Promise<void> => {
   try {
-    await sendRuntimeMessage({ type: MessageType.CLOSE_POPUP });
+    await chrome.runtime.sendMessage({ type: MessageType.CLOSE_POPUP });
   } catch (error) {
     console.error(`Failed to close Content:`, error);
     // WARN: 処理が失敗した場合は Popup のサービスを表示する

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -19,6 +19,37 @@ export interface RuntimeService {
   queryResults: (request: QueryResultsRequest) => Promise<Result<Kind>[]>;
   openContent: () => Promise<void>;
   closeContent: () => Promise<void>;
+  /**
+   * MV3 Service Worker のアイドル停止を防ぐための永続ポート接続を確立する。
+   * 接続が切断された場合（SW 強制終了時）は自動的に再接続する。
+   *
+   * @param name - ポート名（background の onConnect で識別される）
+   * @param onMessage - ポート経由で受信したメッセージのハンドラ（省略可）
+   */
+  connectPort: (name: string, onMessage?: (message: unknown) => void) => void;
+}
+
+// SW の30秒アイドルタイマーをリセットするための ping 間隔
+const KEEPALIVE_INTERVAL_MS = 25000;
+
+function connectPort(
+  name: string,
+  onMessage?: (message: unknown) => void,
+): void {
+  const port = chrome.runtime.connect({ name });
+  const interval = setInterval(
+    () => port.postMessage({ type: "PING" }),
+    KEEPALIVE_INTERVAL_MS,
+  );
+
+  if (onMessage) {
+    port.onMessage.addListener(onMessage);
+  }
+
+  port.onDisconnect.addListener(() => {
+    clearInterval(interval);
+    connectPort(name, onMessage);
+  });
 }
 
 const createTab = async ({ url }: CreateTabRequest): Promise<void> => {
@@ -134,6 +165,7 @@ export const createRuntimeService = (): RuntimeService => ({
   queryResults,
   openContent,
   closeContent,
+  connectPort,
 });
 
 export const runtimeService = createRuntimeService();

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -12,6 +12,38 @@ import type {
 import { RuntimeServiceError } from "./error";
 import { MessageType, type RuntimeResponse } from "./types";
 
+/**
+ * MV3 Service Worker が停止中に sendMessage すると
+ * "Could not establish connection. Receiving end does not exist." が発生する。
+ * この失敗自体が SW を起動するトリガーになるため、
+ * 起動完了を待ってから 1 回だけリトライする。
+ */
+const SW_RESTART_DELAY_MS = 500;
+
+function isConnectionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes("Could not establish connection") ||
+      error.message.includes("Receiving end does not exist"))
+  );
+}
+
+async function sendRuntimeMessage<T>(message: object): Promise<T> {
+  try {
+    return (await chrome.runtime.sendMessage(message)) as T;
+  } catch (error) {
+    if (isConnectionError(error)) {
+      // SW が停止していた場合、上記の sendMessage が起動トリガーになる。
+      // 初期化完了を待ってからリトライする。
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, SW_RESTART_DELAY_MS),
+      );
+      return (await chrome.runtime.sendMessage(message)) as T;
+    }
+    throw error;
+  }
+}
+
 export interface RuntimeService {
   createTab: (request: CreateTabRequest) => Promise<void>;
   updateTab: (request: UpdateTabRequest) => Promise<void>;
@@ -23,7 +55,7 @@ export interface RuntimeService {
 
 const createTab = async ({ url }: CreateTabRequest): Promise<void> => {
   try {
-    await chrome.runtime.sendMessage({
+    await sendRuntimeMessage({
       type: MessageType.CREATE_TAB,
       url,
     });
@@ -45,7 +77,7 @@ const updateTab = async ({
   windowId,
 }: UpdateTabRequest): Promise<void> => {
   try {
-    await chrome.runtime.sendMessage({
+    await sendRuntimeMessage({
       type: MessageType.UPDATE_TAB,
       tabId,
       windowId,
@@ -65,7 +97,7 @@ const updateTab = async ({
 
 const removeTab = async ({ tabId }: RemoveTabRequest): Promise<void> => {
   try {
-    await chrome.runtime.sendMessage({
+    await sendRuntimeMessage({
       type: MessageType.REMOVE_TAB,
       tabId,
     });
@@ -86,10 +118,10 @@ const queryResults = async ({
   filters,
 }: QueryResultsRequest): Promise<Result<Kind>[]> => {
   try {
-    const response = (await chrome.runtime.sendMessage({
+    const response = await sendRuntimeMessage<RuntimeResponse<Result<Kind>[]>>({
       type: MessageType.QUERY_RESULT,
       filters,
-    })) as RuntimeResponse<Result<Kind>[]>;
+    });
 
     return response.result;
   } catch (error) {
@@ -107,7 +139,7 @@ const queryResults = async ({
 
 const openContent = async (): Promise<void> => {
   try {
-    await chrome.runtime.sendMessage({ type: MessageType.OPEN_POPUP });
+    await sendRuntimeMessage({ type: MessageType.OPEN_POPUP });
   } catch (error) {
     console.error(`Failed to open Content:`, error);
     // WARN: 処理が失敗した場合はPopup のサービスを表示する
@@ -118,7 +150,7 @@ const openContent = async (): Promise<void> => {
 
 const closeContent = async (): Promise<void> => {
   try {
-    await chrome.runtime.sendMessage({ type: MessageType.CLOSE_POPUP });
+    await sendRuntimeMessage({ type: MessageType.CLOSE_POPUP });
   } catch (error) {
     console.error(`Failed to close Content:`, error);
     // WARN: 処理が失敗した場合は Popup のサービスを表示する


### PR DESCRIPTION
## Summary

- Closes #121
- `chrome.runtime.connect()` でポートを確立し、SW を起動・生存させる
- 25秒ごとの ping で Chrome の30秒アイドルタイマーをリセット
- ポートが切断された場合（SW強制終了時）は自動的に再接続

## 実装

| ファイル | 変更内容 |
|---|---|
| `runtime/service.ts` | `connectPort(name, onMessage?)` を `RuntimeService` に追加。ポート接続・ping・再接続ロジックをサービス層に集約 |
| `popup/main.tsx` | `runtimeService.connectPort("keepalive")` の1行に簡略化 |
| `sidepanel/main.tsx` | `runtimeService.connectPort("sidepanel", handler)` の1行に簡略化 |
| `background/index.ts` | コメント更新（`keepalive` ポートは接続を受け入れるだけで SW が生存する） |

## 動作の仕組み

```
[popup/sidepanel 起動]
  → runtimeService.connectPort() → chrome.runtime.connect()
  → SW が停止していても自動起動
  → ポート接続が続く限り SW は生存
  → 25秒ごとの ping がアイドルタイマーをリセット
  → ポート切断（SW強制終了）→ 自動再接続で復旧
```

## Test plan

- [ ] 拡張機能を5分以上放置してSWを停止させる
- [ ] ポップアップを開いて検索を試みる → 結果が正常に表示されることを確認
- [ ] サイドパネルを長時間開いたままにして検索が継続して動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)