### PR TITLE
fix: improve result item layout for narrow sidepanel widths

### DIFF
--- a/src/features/search/components/ResultList/part/BookmarkItem/BookmarkItem.tsx
+++ b/src/features/search/components/ResultList/part/BookmarkItem/BookmarkItem.tsx
@@ -59,7 +59,7 @@ const BookmarkItem: React.FC<BookmarkItemProps> = ({
   const RightContent = useMemo(
     () => (
       <div className="flex items-center gap-1.5">
-        <span className="text-xs opacity-50 whitespace-nowrap">
+        <span className={defaultClassName.actionLabel}>
           {t("actions.openTab")}
         </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>

--- a/src/features/search/components/ResultList/part/BookmarkItem/BookmarkItem.tsx
+++ b/src/features/search/components/ResultList/part/BookmarkItem/BookmarkItem.tsx
@@ -31,7 +31,6 @@ const BookmarkItem: React.FC<BookmarkItemProps> = ({
   item,
 }) => {
   const { t } = useTranslation();
-
   const LeftIcon = useMemo(
     () => (
       <SquareIcon>
@@ -59,8 +58,10 @@ const BookmarkItem: React.FC<BookmarkItemProps> = ({
 
   const RightContent = useMemo(
     () => (
-      <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions.openTab")}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs opacity-50 whitespace-nowrap">
+          {t("actions.openTab")}
+        </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(
@@ -86,11 +87,8 @@ const BookmarkItem: React.FC<BookmarkItemProps> = ({
         defaultClassName.hover,
       )}
     >
-      <div
-        id={item.data.id}
-        className="relative flex flex-col items-center justify-center max-w-fit"
-      >
-        <div className="text-sm truncate max-w-[450px] md:max-w-md whitespace-nowrap">
+      <div id={item.data.id} className="min-w-0 w-full">
+        <div className="text-sm truncate whitespace-nowrap">
           {item.data.title || item.data.url}
         </div>
       </div>

--- a/src/features/search/components/ResultList/part/CalculationItem/CalculationItem.tsx
+++ b/src/features/search/components/ResultList/part/CalculationItem/CalculationItem.tsx
@@ -48,7 +48,7 @@ const CalculationItem: React.FC<CalculationItemProps> = ({
   const RightIcon = useMemo(
     () => (
       <div className="flex items-center gap-1.5">
-        <span className="text-xs opacity-50 whitespace-nowrap">
+        <span className={defaultClassName.actionLabel}>
           {t("actions.openResult")}
         </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
@@ -77,11 +77,11 @@ const CalculationItem: React.FC<CalculationItemProps> = ({
       )}
     >
       <div className="flex w-full min-w-0 items-center gap-2 overflow-hidden">
-        <div className="min-w-0 flex-1 truncate text-md">
+        <div className="min-w-0 flex-1 truncate text-sm">
           {item.data.expression}
         </div>
-        <div className="text-md whitespace-nowrap">=</div>
-        <div className="text-lg whitespace-nowrap">{item.data.result}</div>
+        <div className="text-sm whitespace-nowrap">=</div>
+        <div className="text-base whitespace-nowrap">{item.data.result}</div>
       </div>
     </ButtonItem>
   );

--- a/src/features/search/components/ResultList/part/CalculationItem/CalculationItem.tsx
+++ b/src/features/search/components/ResultList/part/CalculationItem/CalculationItem.tsx
@@ -31,7 +31,6 @@ const CalculationItem: React.FC<CalculationItemProps> = ({
   onClick,
 }) => {
   const { t } = useTranslation();
-
   const LeftIcon = useMemo(
     () => (
       <SquareIcon>
@@ -48,8 +47,10 @@ const CalculationItem: React.FC<CalculationItemProps> = ({
 
   const RightIcon = useMemo(
     () => (
-      <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions.openResult")}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs opacity-50 whitespace-nowrap">
+          {t("actions.openResult")}
+        </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(
@@ -75,10 +76,12 @@ const CalculationItem: React.FC<CalculationItemProps> = ({
         defaultClassName.hover,
       )}
     >
-      <div className="flex flex-row items-center space-x-2">
-        <div className="text-md">{item.data.expression}</div>
-        <div className="text-md">=</div>
-        <div className="text-lg">{item.data.result}</div>
+      <div className="flex w-full min-w-0 items-center gap-2 overflow-hidden">
+        <div className="min-w-0 flex-1 truncate text-md">
+          {item.data.expression}
+        </div>
+        <div className="text-md whitespace-nowrap">=</div>
+        <div className="text-lg whitespace-nowrap">{item.data.result}</div>
       </div>
     </ButtonItem>
   );

--- a/src/features/search/components/ResultList/part/HistoryItem/HistoryItem.tsx
+++ b/src/features/search/components/ResultList/part/HistoryItem/HistoryItem.tsx
@@ -26,7 +26,6 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
   item,
 }) => {
   const { t } = useTranslation();
-
   const LeftIcon = useMemo(
     () => (
       <SquareIcon>
@@ -54,8 +53,10 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
 
   const RightContent = useMemo(
     () => (
-      <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions.openTab")}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs opacity-50 whitespace-nowrap">
+          {t("actions.openTab")}
+        </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(
@@ -81,11 +82,8 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
       LeftContent={LeftIcon}
       RightContent={RightContent}
     >
-      <div
-        id={item.data.id}
-        className="relative flex flex-col items-center justify-center max-w-fit"
-      >
-        <div className="text-sm truncate md:max-w-md whitespace-nowrap max-w-[450px]">
+      <div id={item.data.id} className="min-w-0 w-full">
+        <div className="text-sm truncate whitespace-nowrap">
           {item.data.title}
         </div>
       </div>

--- a/src/features/search/components/ResultList/part/HistoryItem/HistoryItem.tsx
+++ b/src/features/search/components/ResultList/part/HistoryItem/HistoryItem.tsx
@@ -54,7 +54,7 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
   const RightContent = useMemo(
     () => (
       <div className="flex items-center gap-1.5">
-        <span className="text-xs opacity-50 whitespace-nowrap">
+        <span className={defaultClassName.actionLabel}>
           {t("actions.openTab")}
         </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>

--- a/src/features/search/components/ResultList/part/SuggestionItem/SuggestionItem.tsx
+++ b/src/features/search/components/ResultList/part/SuggestionItem/SuggestionItem.tsx
@@ -44,7 +44,7 @@ const SuggestionItem: React.FC<SuggestionItemProps> = ({
   const RightContent = useMemo(
     () => (
       <div className="flex items-center gap-1.5">
-        <span className="text-xs opacity-50 whitespace-nowrap">
+        <span className={defaultClassName.actionLabel}>
           {t("actions.openTab")}
         </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>

--- a/src/features/search/components/ResultList/part/SuggestionItem/SuggestionItem.tsx
+++ b/src/features/search/components/ResultList/part/SuggestionItem/SuggestionItem.tsx
@@ -43,8 +43,10 @@ const SuggestionItem: React.FC<SuggestionItemProps> = ({
 
   const RightContent = useMemo(
     () => (
-      <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>{t("actions.openTab")}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs opacity-50 whitespace-nowrap">
+          {t("actions.openTab")}
+        </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
           <PlusIcon
             className={clsx(
@@ -70,8 +72,8 @@ const SuggestionItem: React.FC<SuggestionItemProps> = ({
       LeftContent={LeftIcon}
       RightContent={RightContent}
     >
-      <div className="relative flex flex-col items-center justify-center max-w-fit">
-        <div className="text-sm truncate max-w-[450px] md:max-w-md whitespace-nowrap">
+      <div className="min-w-0 w-full">
+        <div className="text-sm truncate whitespace-nowrap">
           {item.data.title}
         </div>
       </div>

--- a/src/features/search/components/ResultList/part/TabItem/TabItem.tsx
+++ b/src/features/search/components/ResultList/part/TabItem/TabItem.tsx
@@ -48,8 +48,8 @@ const TabItem: React.FC<TabItemProps> = ({ item, onClick, selected }) => {
 
   const RightContent = useMemo(
     () => (
-      <div className="flex items-center space-x-2">
-        <span className={defaultClassName.text}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs opacity-50 whitespace-nowrap">
           {t("actions.switchToTab")}
         </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>
@@ -77,11 +77,8 @@ const TabItem: React.FC<TabItemProps> = ({ item, onClick, selected }) => {
       LeftContent={LeftIcon}
       RightContent={RightContent}
     >
-      <div
-        id={item.data.id?.toString()}
-        className="relative flex flex-col items-center justify-center max-w-fit"
-      >
-        <div className="text-sm truncate max-w-[430px] md:max-w-md whitespace-nowrap">
+      <div id={item.data.id?.toString()} className="min-w-0 w-full">
+        <div className="text-sm truncate whitespace-nowrap">
           {item.data.title}
         </div>
       </div>

--- a/src/features/search/components/ResultList/part/TabItem/TabItem.tsx
+++ b/src/features/search/components/ResultList/part/TabItem/TabItem.tsx
@@ -49,7 +49,7 @@ const TabItem: React.FC<TabItemProps> = ({ item, onClick, selected }) => {
   const RightContent = useMemo(
     () => (
       <div className="flex items-center gap-1.5">
-        <span className="text-xs opacity-50 whitespace-nowrap">
+        <span className={defaultClassName.actionLabel}>
           {t("actions.switchToTab")}
         </span>
         <SquareIcon className={clsx(selected && defaultClassName.icon.bg)}>

--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -125,9 +125,7 @@ export default function SearchApp({
   const isSidepanel = variant === "sidepanel";
 
   return (
-    <Layout
-      className={isSidepanel ? "w-full h-screen" : "min-w-[700px] max-w-min"}
-    >
+    <Layout className={isSidepanel ? "w-full h-screen" : "w-[700px]"}>
       <div
         className={clsx(
           layoutClassName.bg,

--- a/src/shared/components/ButtonItem/ButtonItem.tsx
+++ b/src/shared/components/ButtonItem/ButtonItem.tsx
@@ -24,6 +24,7 @@ export const defaultClassName = {
     size: "size-5",
   },
   text: "dark:text-gray-300 text-xs font-medium",
+  actionLabel: "text-xs opacity-50 whitespace-nowrap",
 };
 
 const ButtonItem: React.FC<ButtonItemProps> = (props) => {

--- a/src/shared/components/ButtonItem/ButtonItem.tsx
+++ b/src/shared/components/ButtonItem/ButtonItem.tsx
@@ -43,9 +43,9 @@ const ButtonItem: React.FC<ButtonItemProps> = (props) => {
         {props.LeftContent && (
           <div className="flex-none">{props.LeftContent}</div>
         )}
-        <div className="flex-1">{props.children}</div>
+        <div className="flex-1 min-w-0">{props.children}</div>
         {props.RightContent && (
-          <div className="flex-none">{props.RightContent}</div>
+          <div className="flex-none ml-3">{props.RightContent}</div>
         )}
       </button>
     </li>


### PR DESCRIPTION
## Summary

- Add `min-w-0` to `ButtonItem`'s `flex-1` child so titles can shrink and `RightContent` stays visible in narrow sidepanel widths
- Replace fixed pixel max-widths (`max-w-[430px]` etc.) with `w-full min-w-0` on title wrappers in all result items
- Apply `opacity-50 whitespace-nowrap` to RightContent action labels for visual distinction from title text
- Fix `CalculationItem` content wrapper with `overflow-hidden` and truncation for consistency (found by Codex review)
- Set popup width to `w-[700px]` fixed (was `min-w-[700px] max-w-min`)

## Test plan

- [ ] Open popup — width is fixed at 700px, layout looks correct
- [ ] Open sidepanel — titles truncate properly and action icons/labels remain visible at any width
- [ ] Long tab/bookmark/history titles truncate with `…` and do not push RightContent off screen
- [ ] RightContent label text (e.g. "Open Tab") is visually distinct from title text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR サマリー

## 目的
狭いサイドパネルの幅における結果アイテムのレイアウトを改善し、タイトルが適切に縮小され、右側のコンテンツが常に表示されるようにします。

## 主な変更内容

### フレックスボックスレイアウトの改善
- `ButtonItem` の `flex-1` を持つ子要素に `min-w-0` を追加し、テキストの縮小と右側のコンテンツの表示を両立
- タイトルラッパーに対して固定ピクセル幅の `max-w-[430px]` などを `w-full min-w-0` に置き換え

### 右側コンテンツのスタイリング改善
- `RightContent` のアクション標をスタイル更新：`text-xs opacity-50 whitespace-nowrap` を適用
- ギャップを `space-x-2` から `gap-1.5` に変更
- タイトルテキストとの視覚的な区別を強化

### コンポーネント別の調整
- **BookmarkItem**: タイトルコンテナを `min-w-0 w-full` に更新、右側ラベルを小さく半透明化
- **CalculationItem**: コンテンツラッパーに `overflow-hidden` を追加、数式部分を縮小可能に、結果を1行に固定
- **HistoryItem**: タイトルコンテナの最大幅制約を削除し、`min-w-0 w-full` で対応
- **SuggestionItem**: 右側ラベルのスタイルを統一、タイトルコンテナをフルウィッド化
- **TabItem**: レイアウト構造を簡潔化し、タイトルコンテナを `min-w-0 w-full` で統一

### ポップアップサイズの固定
- `SearchApp` のポップアップ幅を `min-w-[700px] max-w-min` から固定幅 `w-[700px]` に変更
- サイドパネル時のサイズ `w-full h-screen` は変更なし

## テスト観点
- ポップアップを開いて、幅が700pxで固定されていることを確認
- サイドパネルを開いて、長いタイトルが適切に省略記号で切り詰められることを確認
- サイドパネルの幅を変更した際、アクションアイコン/ラベルがオフスクリーンにならないことを確認
- 右側のラベルテキスト（「Open Tab」など）がタイトルと視覚的に区別されていることを確認

## ファイル変更統計
- 6ファイル変更
- 総行数変更: +35/-37
- レビュー難易度: 低～中程度

<!-- end of auto-generated comment: release notes by coderabbit.ai -->