### PR TITLE
fix: QUERY_RESULT error response, categories mutation, duplicate storage listeners

### DIFF
--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -115,6 +115,7 @@ export function routeMessage(
         })
         .catch((error) => {
           console.error("Error handling QUERY_RESULT:", error);
+          sendResponse(QUERY_RESULT, [], response);
         });
       return true;
     }

--- a/src/features/search/hooks/useSearchResults/helper.ts
+++ b/src/features/search/hooks/useSearchResults/helper.ts
@@ -16,7 +16,7 @@ export function generateCacheKey(
   categories: Kind[],
 ): string {
   const q = query || "";
-  const c = categories.sort().join(",");
+  const c = [...categories].sort().join(",");
   return `${q}::${c}`;
 }
 

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -39,7 +39,7 @@ const hydrateViewMode = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
-  if (newViewMode) updateSnapshot(newViewMode);
+  updateSnapshot(newViewMode ?? getDefaultViewMode());
 });
 
 void hydrateViewMode();

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -21,13 +21,6 @@ const updateSnapshot = (viewMode: ViewModeValue) => {
   notify();
 };
 
-const subscribeExternalChanges = () =>
-  storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
-    if (newViewMode) {
-      updateSnapshot(newViewMode);
-    }
-  });
-
 const subscribe = (listener: () => void) => {
   listeners.add(listener);
   return () => listeners.delete(listener);
@@ -45,21 +38,14 @@ const hydrateViewMode = async () => {
   }
 };
 
+storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
+  if (newViewMode) updateSnapshot(newViewMode);
+});
+
 void hydrateViewMode();
 
 export default function useViewMode() {
-  const viewMode = useSyncExternalStore(
-    (listener) => {
-      const unsubscribeInternal = subscribe(listener);
-      const unsubscribeExternal = subscribeExternalChanges();
-      return () => {
-        unsubscribeInternal();
-        unsubscribeExternal();
-      };
-    },
-    getSnapshot,
-    getSnapshot,
-  );
+  const viewMode = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const setViewMode = useCallback((value: ViewModeValue) => {
     updateSnapshot(value);

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -41,13 +41,6 @@ const updateSnapshot = (theme: ThemeValue) => {
   notify();
 };
 
-const subscribeExternalChanges = () =>
-  storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
-    if (newTheme) {
-      updateSnapshot(newTheme);
-    }
-  });
-
 const subscribe = (listener: () => void) => {
   listeners.add(listener);
   return () => listeners.delete(listener);
@@ -65,18 +58,15 @@ const hydrateTheme = async () => {
   }
 };
 
+storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
+  if (newTheme) updateSnapshot(newTheme);
+});
+
 void hydrateTheme();
 
 export default function useTheme() {
   const { theme, isDarkMode } = useSyncExternalStore(
-    (listener) => {
-      const unsubscribeInternal = subscribe(listener);
-      const unsubscribeExternal = subscribeExternalChanges();
-      return () => {
-        unsubscribeInternal();
-        unsubscribeExternal();
-      };
-    },
+    subscribe,
     getSnapshot,
     getSnapshot,
   );

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -59,7 +59,7 @@ const hydrateTheme = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
-  if (newTheme) updateSnapshot(newTheme);
+  updateSnapshot(newTheme ?? getDefaultTheme());
 });
 
 void hydrateTheme();


### PR DESCRIPTION
## Summary

- **#144 (priority: high)** — `QUERY_RESULT` error handler now calls `sendResponse` with an empty array so the UI gets an immediate response instead of waiting 10 seconds for the timeout
- **#145** — `generateCacheKey` now copies categories with spread before sorting, preventing silent mutation of React state
- **#146** — `storageService.subscribe` is called once at module level in `useTheme` and `useViewMode` instead of once per `useSyncExternalStore` subscriber, eliminating duplicate Chrome Storage listeners

## Test plan

- [x] Trigger a background error during search — UI should recover quickly rather than spinning for 10 seconds
- [x] Verify theme switching still works correctly
- [x] Verify view mode switching still works correctly
- [ ] Check React DevTools shows categories in original insertion order

Closes #144, #145, #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR サマリー: QUERY_RESULT エラーレスポンス、カテゴリー変更、重複ストレージリスナーの修正

## 概要

このPRは3つの重要なバグ修正を実装しています:

1. **QUERY_RESULT エラーレスポンス（#144）**: バックグラウンドで検索結果クエリエラーが発生した場合、即座にUIへレスポンスを返すようにしました。これにより、10秒のタイムアウト待機によるUXの低下を防ぎます。

2. **カテゴリー配列の変更防止（#145）**: `generateCacheKey`関数がReact状態を意図せず変更しないよう、ソート前に配列をコピーするようにしました。

3. **重複ストレージリスナーの削除（#146）**: テーマとビューモード機能において、`storageService.subscribe`をモジュールレベルで一度だけ登録し、コンポーネント毎のリスナー重複を排除しました。

## 変更内容

### `src/entrypoints/background/router/message.ts`
`QUERY_RESULT`メッセージハンドラーの例外処理を改善しました。`resultService.query()`がエラーを投げた場合、キャッチブロックでエラーをログに記録し、即座に空配列を含むレスポンスを送信します。これによってUIがタイムアウトを待つことなく迅速に復帰できます。

### `src/features/search/hooks/useSearchResults/helper.ts`
`generateCacheKey`関数を修正し、受け取ったカテゴリー配列をソート前にスプレッド演算子でコピーするようにしました。これにより元の配列への副作用がなくなり、React状態の意図しない変更を防ぎます。キャッシュキー形式は変わらず`"<query>::<sorted categories>"`のままです。

### `src/features/settings/hooks/useViewMode.ts`
ストレージ購読ロジックを、コンポーネント毎の購読/購読解除から、モジュールレベルの一度きりの購読へ移行しました。モジュール直下で`storageService.subscribe(SyncStorageKey.ViewMode, ...)`を登録し、外部変更時に共有の`snapshot`を`updateSnapshot`で更新します。`useSyncExternalStore`は内部リスナー管理のみを担当するようになります。

### `src/features/theme/hooks/useTheme.ts`
テーマ機能のストレージ購読をビューモード同様にモジュールレベルで一度だけ登録するように変更しました。`SyncStorageKey.Theme`の変更を監視してスナップショットを更新し、`useSyncExternalStore`はReactの内部リスナー登録/解除に専念します。

## テスト方針

- 検索中にバックグラウンドエラーをトリガーし、UIが10秒待機なしで迅速に復帰することを確認
- テーマ切り替え機能の動作確認
- ビューモード切り替え機能の動作確認
- React DevToolsでカテゴリーが元の挿入順で表示されることを確認

## 関連Issue

Closes: #144, #145, #146

<!-- end of auto-generated comment: release notes by coderabbit.ai -->