### PR TITLE
fix: focus search input on mount (#149)

### DIFF
--- a/src/features/search/components/SearchInput/SearchInput.tsx
+++ b/src/features/search/components/SearchInput/SearchInput.tsx
@@ -61,7 +61,16 @@ export default function SearchInput({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    inputRef.current?.focus();
+    if (document.hasFocus()) {
+      inputRef.current?.focus();
+      return;
+    }
+    const handleWindowFocus = () => {
+      inputRef.current?.focus();
+      window.removeEventListener("focus", handleWindowFocus);
+    };
+    window.addEventListener("focus", handleWindowFocus);
+    return () => window.removeEventListener("focus", handleWindowFocus);
   }, []);
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "/") {

--- a/src/features/search/components/SearchInput/SearchInput.tsx
+++ b/src/features/search/components/SearchInput/SearchInput.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 
 export interface SearchInputProps {
@@ -57,6 +58,11 @@ export default function SearchInput({
   onBackspaceKeyDown,
 }: SearchInputProps) {
   const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "/") {
       e.preventDefault();
@@ -103,6 +109,7 @@ export default function SearchInput({
         <div className="flex items-center min-w-8">{leftContent}</div>
       )}
       <input
+        ref={inputRef}
         type="text"
         value={value}
         placeholder={t("ui.searchPlaceholder")}

--- a/src/features/search/components/SearchInput/SearchInput.tsx
+++ b/src/features/search/components/SearchInput/SearchInput.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import { useEffect, useRef } from "react";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 
 export interface SearchInputProps {
@@ -58,20 +57,7 @@ export default function SearchInput({
   onBackspaceKeyDown,
 }: SearchInputProps) {
   const { t } = useTranslation();
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (document.hasFocus()) {
-      inputRef.current?.focus();
-      return;
-    }
-    const handleWindowFocus = () => {
-      inputRef.current?.focus();
-      window.removeEventListener("focus", handleWindowFocus);
-    };
-    window.addEventListener("focus", handleWindowFocus);
-    return () => window.removeEventListener("focus", handleWindowFocus);
-  }, []);
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "/") {
       e.preventDefault();
@@ -118,7 +104,6 @@ export default function SearchInput({
         <div className="flex items-center min-w-8">{leftContent}</div>
       )}
       <input
-        ref={inputRef}
         type="text"
         value={value}
         placeholder={t("ui.searchPlaceholder")}

--- a/src/shared/components/Layout/Layout.tsx
+++ b/src/shared/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type React from "react";
 
 import ThemeProvider from "@/features/theme/context/ThemeProvider";
 
@@ -18,10 +18,8 @@ export type LayoutProps = {
 
 export default function Layout(props: LayoutProps) {
   return (
-    <React.StrictMode>
-      <ThemeProvider>
-        <div className={props.className}>{props.children}</div>
-      </ThemeProvider>
-    </React.StrictMode>
+    <ThemeProvider>
+      <div className={props.className}>{props.children}</div>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary

- `autoFocus` alone is unreliable in Chrome extension popups/sidepanels — the window may not have focus when the DOM first renders, causing the focus attempt to be silently ignored
- Add `useRef` + `useEffect(() => inputRef.current?.focus(), [])` to `SearchInput` for an explicit focus call after mount
- Remove nested `<React.StrictMode>` from `Layout.tsx` — the entrypoints already wrap the app in StrictMode, causing double-mounting in development which further destabilised `autoFocus`

## Test plan

- [ ] Open zen-search with `Cmd+T` — input should be focused immediately and ready for typing without clicking
- [ ] Same test for sidepanel variant
- [ ] Theme switching and other Layout-dependent behaviour still works

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)