### PR TITLE
fix: dev-only logging in storage service and remove dead validation code

### DIFF
--- a/src/features/search/hooks/useSearch/hook.ts
+++ b/src/features/search/hooks/useSearch/hook.ts
@@ -2,11 +2,11 @@
  * 検索クエリと状態を管理するhook
  */
 
-import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import { categoriesMap, initialState } from "./constants";
 import { matchType } from "./helper";
 import { queryReducer } from "./reducer";
-import type { ResultType, UseSearchOptions, ValidationResult } from "./types";
+import type { ResultType, UseSearchOptions } from "./types";
 
 /**
  * 検索クエリと状態を管理するhook
@@ -112,22 +112,6 @@ export default function useSearch(options: UseSearchOptions = {}) {
     dispatch({ type: "resetType" });
   }, []);
 
-  /**
-   * クエリのバリデーション結果
-   */
-  const validation = useMemo<ValidationResult>(() => {
-    const errors: string[] = [];
-
-    if (state.query.length > maxQueryLength) {
-      errors.push(`Query exceeds maximum length of ${maxQueryLength}`);
-    }
-
-    return {
-      isValid: errors.length === 0,
-      errors,
-    };
-  }, [state.query, maxQueryLength]);
-
   return {
     /** 現在の検索状態 */
     state,
@@ -135,8 +119,6 @@ export default function useSearch(options: UseSearchOptions = {}) {
     debouncedQuery,
     /** IME入力中かどうか */
     isComposing,
-    /** バリデーション結果 */
-    validation,
     /** クエリを設定 */
     setQuery,
     /** タイプを更新 */

--- a/src/features/search/hooks/useSearch/index.ts
+++ b/src/features/search/hooks/useSearch/index.ts
@@ -8,5 +8,4 @@ export type {
   QueryState,
   ResultType,
   UseSearchOptions,
-  ValidationResult,
 } from "./types";

--- a/src/features/search/hooks/useSearch/types.ts
+++ b/src/features/search/hooks/useSearch/types.ts
@@ -40,11 +40,3 @@ export interface UseSearchOptions {
   /** suggestion判定の類似度閾値（0-1）。デフォルト: 0.6 */
   similarityThreshold?: number;
 }
-
-/** バリデーション結果 */
-export interface ValidationResult {
-  /** バリデーションが成功したか */
-  isValid: boolean;
-  /** エラーメッセージの配列 */
-  errors: string[];
-}

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -38,8 +38,9 @@ const getStorage = async <K extends Type.SyncStorageKey>({
   try {
     return await chromeStorageGet(key);
   } catch (error) {
-    if (import.meta.env.DEV)
+    if (import.meta.env.DEV) {
       console.warn(`[storageService] get(${key}) failed:`, error);
+    }
     throw new Error(`ストレージの取得に失敗しました: ${key}`);
   }
 };
@@ -68,8 +69,9 @@ const setStorage = async <K extends Type.SyncStorageKey>({
   try {
     return await chromeStorageSet(key, value);
   } catch (error) {
-    if (import.meta.env.DEV)
+    if (import.meta.env.DEV) {
       console.warn(`[storageService] set(${key}) failed:`, error);
+    }
     throw new Error(`ストレージの保存に失敗しました: ${key}`);
   }
 };
@@ -79,8 +81,9 @@ const getTheme = async (): Promise<Type.ThemeValue> => {
     const theme = await chromeStorageGet(SyncStorageKey.Theme);
     return theme || getDefaultTheme();
   } catch (error) {
-    if (import.meta.env.DEV)
+    if (import.meta.env.DEV) {
       console.warn("[storageService] getTheme failed:", error);
+    }
     return getDefaultTheme();
   }
 };
@@ -89,8 +92,9 @@ const setTheme = async ({ theme }: Type.SetThemeRequest): Promise<boolean> => {
   try {
     return await chromeStorageSet(SyncStorageKey.Theme, theme);
   } catch (error) {
-    if (import.meta.env.DEV)
+    if (import.meta.env.DEV) {
       console.warn("[storageService] setTheme failed:", error);
+    }
     throw new Error("テーマの保存に失敗しました");
   }
 };
@@ -100,8 +104,9 @@ const getViewMode = async (): Promise<Type.ViewModeValue> => {
     const viewMode = await chromeStorageGet(SyncStorageKey.ViewMode);
     return isValidViewMode(viewMode) ? viewMode : getDefaultViewMode();
   } catch (error) {
-    if (import.meta.env.DEV)
+    if (import.meta.env.DEV) {
       console.warn("[storageService] getViewMode failed:", error);
+    }
     return getDefaultViewMode();
   }
 };
@@ -110,8 +115,9 @@ const setViewMode = async (viewMode: Type.ViewModeValue): Promise<boolean> => {
   try {
     return await chromeStorageSet(SyncStorageKey.ViewMode, viewMode);
   } catch (error) {
-    if (import.meta.env.DEV)
+    if (import.meta.env.DEV) {
       console.warn("[storageService] setViewMode failed:", error);
+    }
     throw new Error("表示モードの保存に失敗しました");
   }
 };

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -38,7 +38,8 @@ const getStorage = async <K extends Type.SyncStorageKey>({
   try {
     return await chromeStorageGet(key);
   } catch (error) {
-    console.error(`Failed to get storage for key ${key}:`, error);
+    if (import.meta.env.DEV)
+      console.warn(`[storageService] get(${key}) failed:`, error);
     throw new Error(`ストレージの取得に失敗しました: ${key}`);
   }
 };
@@ -67,7 +68,8 @@ const setStorage = async <K extends Type.SyncStorageKey>({
   try {
     return await chromeStorageSet(key, value);
   } catch (error) {
-    console.error(`Failed to set storage for key ${key}:`, error);
+    if (import.meta.env.DEV)
+      console.warn(`[storageService] set(${key}) failed:`, error);
     throw new Error(`ストレージの保存に失敗しました: ${key}`);
   }
 };
@@ -77,8 +79,8 @@ const getTheme = async (): Promise<Type.ThemeValue> => {
     const theme = await chromeStorageGet(SyncStorageKey.Theme);
     return theme || getDefaultTheme();
   } catch (error) {
-    console.error("Failed to get theme:", error);
-    // エラー時はデフォルトテーマを返す
+    if (import.meta.env.DEV)
+      console.warn("[storageService] getTheme failed:", error);
     return getDefaultTheme();
   }
 };
@@ -87,7 +89,8 @@ const setTheme = async ({ theme }: Type.SetThemeRequest): Promise<boolean> => {
   try {
     return await chromeStorageSet(SyncStorageKey.Theme, theme);
   } catch (error) {
-    console.error("Failed to set theme:", error);
+    if (import.meta.env.DEV)
+      console.warn("[storageService] setTheme failed:", error);
     throw new Error("テーマの保存に失敗しました");
   }
 };
@@ -97,7 +100,8 @@ const getViewMode = async (): Promise<Type.ViewModeValue> => {
     const viewMode = await chromeStorageGet(SyncStorageKey.ViewMode);
     return isValidViewMode(viewMode) ? viewMode : getDefaultViewMode();
   } catch (error) {
-    console.error("Failed to get viewMode:", error);
+    if (import.meta.env.DEV)
+      console.warn("[storageService] getViewMode failed:", error);
     return getDefaultViewMode();
   }
 };
@@ -106,7 +110,8 @@ const setViewMode = async (viewMode: Type.ViewModeValue): Promise<boolean> => {
   try {
     return await chromeStorageSet(SyncStorageKey.ViewMode, viewMode);
   } catch (error) {
-    console.error("Failed to set viewMode:", error);
+    if (import.meta.env.DEV)
+      console.warn("[storageService] setViewMode failed:", error);
     throw new Error("表示モードの保存に失敗しました");
   }
 };


### PR DESCRIPTION
## Summary
- **#126**: Replace `console.error` with `import.meta.env.DEV`-guarded `console.warn` in `storageService` — logs are now tree-shaken from production builds
- **#147**: Remove dead `validation` useMemo from `useSearch` — `setQuery` always pre-truncates to `maxQueryLength`, so the error branch was unreachable; clean up `ValidationResult` type and its export

## Test plan
- [ ] `pnpm compile` passes (no TypeScript errors)
- [ ] `pnpm check` passes (no lint/format issues)
- [ ] Storage errors in dev still print to console; silent in production build
- [ ] `useSearch` still works normally (query, type, suggestion, reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)