### PR TITLE
feat: add ErrorBoundary component and Result type guards

### DIFF
--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -1,7 +1,12 @@
 import { useCallback } from "react";
 import SearchApp from "@/features/search/components/SearchApp/SearchApp";
+import ErrorBoundary from "@/shared/components/ErrorBoundary/ErrorBoundary";
 
 export default function App() {
   const handleClose = useCallback(() => window.close(), []);
-  return <SearchApp onClose={handleClose} />;
+  return (
+    <ErrorBoundary>
+      <SearchApp onClose={handleClose} />
+    </ErrorBoundary>
+  );
 }

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -1,5 +1,10 @@
 import SearchApp from "@/features/search/components/SearchApp/SearchApp";
+import ErrorBoundary from "@/shared/components/ErrorBoundary/ErrorBoundary";
 
 export default function App() {
-  return <SearchApp variant="sidepanel" />;
+  return (
+    <ErrorBoundary>
+      <SearchApp variant="sidepanel" />
+    </ErrorBoundary>
+  );
 }

--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -15,8 +15,7 @@ import useSearch from "@/features/search/hooks/useSearch";
 import useSearchKeyboard from "@/features/search/hooks/useSearchKeyboard";
 import useSearchResults from "@/features/search/hooks/useSearchResults";
 import useSearchShortcut from "@/features/search/hooks/useSearchShortcut";
-import type { Kind, Result } from "@/services/result";
-import { isTabResult } from "@/services/result";
+import { isTabResult, type Kind, type Result } from "@/services/result";
 import Layout, {
   commonClassName as layoutClassName,
 } from "@/shared/components/Layout/Layout";

--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -16,6 +16,7 @@ import useSearchKeyboard from "@/features/search/hooks/useSearchKeyboard";
 import useSearchResults from "@/features/search/hooks/useSearchResults";
 import useSearchShortcut from "@/features/search/hooks/useSearchShortcut";
 import type { Kind, Result } from "@/services/result";
+import { isTabResult } from "@/services/result";
 import Layout, {
   commonClassName as layoutClassName,
 } from "@/shared/components/Layout/Layout";
@@ -54,9 +55,8 @@ export default function SearchApp({
     (result: Result<Kind>) => {
       onClose();
 
-      if (result.type === "Tab") {
-        const tab = result as Result<"Tab">;
-        const { id: tabId, windowId } = tab.data;
+      if (isTabResult(result)) {
+        const { id: tabId, windowId } = result.data;
         updateTab(tabId, windowId);
         return;
       }

--- a/src/services/result/index.ts
+++ b/src/services/result/index.ts
@@ -5,3 +5,10 @@
 export * from "./helper";
 export { type ResultService, resultService } from "./service";
 export type * from "./types";
+export {
+  isActionResult,
+  isBookmarkResult,
+  isHistoryResult,
+  isSuggestionResult,
+  isTabResult,
+} from "./types";

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -29,6 +29,35 @@ export type ResultDataMap = {
 
 export type ResultData<T extends Kind> = ResultDataMap[T];
 
+/** Result<Kind> を特定の型に絞り込む型ガード関数 */
+export function isTabResult(result: Result<Kind>): result is Result<"Tab"> {
+  return result.type === "Tab";
+}
+
+export function isBookmarkResult(
+  result: Result<Kind>,
+): result is Result<"Bookmark"> {
+  return result.type === "Bookmark";
+}
+
+export function isHistoryResult(
+  result: Result<Kind>,
+): result is Result<"History"> {
+  return result.type === "History";
+}
+
+export function isSuggestionResult(
+  result: Result<Kind>,
+): result is Result<"Suggestion"> {
+  return result.type === "Suggestion";
+}
+
+export function isActionResult(
+  result: Result<Kind>,
+): result is Result<"Action.Calculation"> {
+  return result.type === "Action.Calculation";
+}
+
 export interface QueryResultsRequest {
   filters: ResultFilters;
 }

--- a/src/shared/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/shared/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import ErrorBoundary, { type ErrorBoundaryProps } from "./ErrorBoundary";
+
+const meta: Meta = {
+  component: ErrorBoundary,
+};
+
+export default meta;
+
+type Story = StoryObj<ErrorBoundaryProps>;
+
+function ThrowError(): never {
+  throw new Error("Unexpected render error");
+}
+
+export const Default: Story = {
+  args: {
+    children: <div className="p-4 text-sm">正常なコンテンツ</div>,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    children: <ThrowError />,
+  },
+};
+
+export const WithCustomFallback: Story = {
+  args: {
+    children: <ThrowError />,
+    fallback: (
+      <div className="p-4 text-sm text-yellow-500">カスタムフォールバック</div>
+    ),
+  },
+};

--- a/src/shared/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+type State = { hasError: boolean; error: Error | null };
+
+export type ErrorBoundaryProps = {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+};
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    if (import.meta.env.DEV) {
+      console.warn("[ErrorBoundary]", error, info);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div className="p-4 text-sm text-red-500">
+            予期しないエラーが発生しました。拡張機能を再起動してください。
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- **#134**: `ErrorBoundary` クラスコンポーネントを `src/shared/components/ErrorBoundary/` に追加し、popup/sidepanel の両エントリポイントで `SearchApp` をラップ。予期しないレンダーエラーをキャッチしてフォールバックメッセージを表示（白画面防止）
- **#123**: `isTabResult` / `isBookmarkResult` / `isHistoryResult` / `isSuggestionResult` / `isActionResult` 型ガード関数を result service に追加し、`SearchApp` の `as Result<"Tab">` キャストを `isTabResult()` に置き換えて TypeScript の型絞り込みが確実に機能するよう改善
- **#132**: popup App.tsx では `useCallback` 済み、sidepanel は `onClose` prop なし — 対応済みとしてクローズ

## Test plan
- [ ] `pnpm compile` passes
- [ ] `pnpm check` passes
- [ ] popup でタブを選択したとき正常にタブが切り替わる
- [ ] フック内でエラーが発生したとき白画面ではなくフォールバックメッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)