### PR TITLE
feat: search engine switching with multi-select toggle (A-1)

### DIFF
--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -15,6 +15,7 @@ import useSearch from "@/features/search/hooks/useSearch";
 import useSearchKeyboard from "@/features/search/hooks/useSearchKeyboard";
 import useSearchResults from "@/features/search/hooks/useSearchResults";
 import useSearchShortcut from "@/features/search/hooks/useSearchShortcut";
+import useSearchEngines from "@/features/settings/hooks/useSearchEngine";
 import { isTabResult, type Kind, type Result } from "@/services/result";
 import Layout, {
   commonClassName as layoutClassName,
@@ -43,9 +44,12 @@ export default function SearchApp({
     setIsComposing,
   } = useSearch();
 
+  const { searchEngines } = useSearchEngines();
+
   const { results, loading: resultsLoading } = useSearchResults({
     query: debouncedQuery,
     categories,
+    searchEngines,
   });
 
   const { updateTab, createTab } = useControlTab();

--- a/src/features/search/components/SearchApp/SearchApp.tsx
+++ b/src/features/search/components/SearchApp/SearchApp.tsx
@@ -15,7 +15,7 @@ import useSearch from "@/features/search/hooks/useSearch";
 import useSearchKeyboard from "@/features/search/hooks/useSearchKeyboard";
 import useSearchResults from "@/features/search/hooks/useSearchResults";
 import useSearchShortcut from "@/features/search/hooks/useSearchShortcut";
-import useSearchEngines from "@/features/settings/hooks/useSearchEngine";
+import useSearchEngines from "@/features/settings/hooks/useSearchEngines";
 import { isTabResult, type Kind, type Result } from "@/services/result";
 import Layout, {
   commonClassName as layoutClassName,

--- a/src/features/search/hooks/useSearchResults/helper.ts
+++ b/src/features/search/hooks/useSearchResults/helper.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Kind } from "@/services/result";
+import type { SearchEngineValue } from "@/services/storage/types";
 import type { CacheEntry } from "./types";
 
 /**
@@ -14,7 +15,7 @@ import type { CacheEntry } from "./types";
 export function generateCacheKey(
   query: string | undefined,
   categories: Kind[],
-  searchEngines?: string[],
+  searchEngines?: SearchEngineValue[],
 ): string {
   const q = query || "";
   const c = [...categories].sort().join(",");

--- a/src/features/search/hooks/useSearchResults/helper.ts
+++ b/src/features/search/hooks/useSearchResults/helper.ts
@@ -14,10 +14,12 @@ import type { CacheEntry } from "./types";
 export function generateCacheKey(
   query: string | undefined,
   categories: Kind[],
+  searchEngines?: string[],
 ): string {
   const q = query || "";
   const c = [...categories].sort().join(",");
-  return `${q}::${c}`;
+  const e = searchEngines ? [...searchEngines].sort().join(",") : "";
+  return `${q}::${c}::${e}`;
 }
 
 /**

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -79,9 +79,10 @@ export default function useSearchResults(
     async (
       query: string | undefined,
       categories: Kind[],
+      searchEngines: UseSearchResultsParams["searchEngines"],
     ): Promise<Result<Kind>[]> => {
       // キャッシュキー生成
-      const cacheKey = generateCacheKey(query, categories);
+      const cacheKey = generateCacheKey(query, categories, searchEngines);
 
       // キャッシュチェック
       if (opts.enableCache) {
@@ -94,7 +95,7 @@ export default function useSearchResults(
       // API呼び出し
       const fetchFn = async () => {
         const results = await runtimeService.queryResults({
-          filters: { query, categories, count: maxCount },
+          filters: { query, categories, count: maxCount, searchEngines },
         });
         return results;
       };
@@ -135,7 +136,11 @@ export default function useSearchResults(
     setError(null);
 
     try {
-      const results = await fetchResults(params.query, params.categories);
+      const results = await fetchResults(
+        params.query,
+        params.categories,
+        params.searchEngines,
+      );
       if (requestId !== requestIdRef.current) return;
       setResults(results);
       setLoadingState("success");
@@ -174,7 +179,7 @@ export default function useSearchResults(
       setLoadingState("error");
       console.error("Failed to fetch search results:", err);
     }
-  }, [fetchResults, params.query, params.categories]);
+  }, [fetchResults, params.query, params.categories, params.searchEngines]);
 
   /**
    * キャッシュをクリア

--- a/src/features/search/hooks/useSearchResults/types.ts
+++ b/src/features/search/hooks/useSearchResults/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Kind, Result } from "@/services/result";
+import type { SearchEngineValue } from "@/services/storage/types";
 
 /** ローディング状態 */
 export type LoadingState = "idle" | "loading" | "success" | "error";
@@ -15,6 +16,8 @@ export interface UseSearchResultsParams {
   categories: Kind[];
   /** 取得する最大件数。デフォルト: 1000 */
   maxCount?: number;
+  /** 有効な検索エンジン一覧 */
+  searchEngines?: SearchEngineValue[];
 }
 
 /** 検索結果のオプション */

--- a/src/features/settings/components/SettingsButton/SettingsButton.tsx
+++ b/src/features/settings/components/SettingsButton/SettingsButton.tsx
@@ -9,7 +9,7 @@ import SunIcon from "@heroicons/react/16/solid/SunIcon";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import clsx from "clsx";
 import { useCallback, useContext } from "react";
-import useSearchEngines from "@/features/settings/hooks/useSearchEngine";
+import useSearchEngines from "@/features/settings/hooks/useSearchEngines";
 import useViewMode from "@/features/settings/hooks/useViewMode";
 import { ThemeContext } from "@/features/theme/context/ThemeProvider";
 import { MessageType } from "@/services/runtime/types";

--- a/src/features/settings/components/SettingsButton/SettingsButton.tsx
+++ b/src/features/settings/components/SettingsButton/SettingsButton.tsx
@@ -1,4 +1,4 @@
-import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import Cog6ToothIcon from "@heroicons/react/16/solid/Cog6ToothIcon";
 import ComputerDesktopIcon from "@heroicons/react/16/solid/ComputerDesktopIcon";
 import GlobeAltIcon from "@heroicons/react/16/solid/GlobeAltIcon";
@@ -108,9 +108,12 @@ export default function SettingsButton(props: SettingsButtonProps) {
     { value: "perplexity", label: t("searchEngines.perplexity") },
   ];
 
+  const itemClassName =
+    "flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300";
+
   return (
-    <Menu>
-      <MenuButton
+    <Popover>
+      <PopoverButton
         aria-label={t("settings.open")}
         className={clsx(
           "flex items-center hover:cursor-pointer hover:bg-gray-400 dark:hover:bg-gray-700 group relative space-x-2 p-1 rounded-md focus:outline-none",
@@ -119,21 +122,21 @@ export default function SettingsButton(props: SettingsButtonProps) {
         )}
       >
         <Cog6ToothIcon className="size-5" />
-      </MenuButton>
-      <MenuItems
-        transition
+      </PopoverButton>
+      <PopoverPanel
         anchor="top start"
+        transition
         className="transition duration-200 ease-in-out bg-white border-2 border-gray-600 rounded-lg shadow-lg focus:outline-none dark:bg-gray-800 [--anchor-gap:--spacing(1)] data-[closed]:opacity-0 data-[closed]:scale-95"
       >
         <div className="px-3 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
           {t("settings.theme")}
         </div>
         {themes.map((item) => (
-          <MenuItem
-            as="button"
+          <button
+            type="button"
             disabled={theme === item.value}
             key={item.value}
-            className="flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300"
+            className={itemClassName}
             onClick={() => setTheme(item.value)}
           >
             <ThemeIcon theme={item.value} className="size-5" />
@@ -141,18 +144,18 @@ export default function SettingsButton(props: SettingsButtonProps) {
             {theme === item.value && (
               <CheckCircleIcon className="flex-none ml-auto size-5" />
             )}
-          </MenuItem>
+          </button>
         ))}
         <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
         <div className="px-3 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
           {t("settings.viewMode")}
         </div>
         {modes.map((item) => (
-          <MenuItem
-            as="button"
+          <button
+            type="button"
             disabled={viewMode === item.value}
             key={item.value}
-            className="flex items-center w-full px-3 py-2 space-x-2 text-gray-800 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700 dark:text-gray-300"
+            className={itemClassName}
             onClick={() => handleViewModeChange(item.value)}
           >
             <ViewModeIcon mode={item.value} className="size-5" />
@@ -160,7 +163,7 @@ export default function SettingsButton(props: SettingsButtonProps) {
             {viewMode === item.value && (
               <CheckCircleIcon className="flex-none ml-auto size-5" />
             )}
-          </MenuItem>
+          </button>
         ))}
         <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
         <div className="px-3 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
@@ -170,8 +173,8 @@ export default function SettingsButton(props: SettingsButtonProps) {
           const enabled = searchEngines.includes(item.value);
           const isLast = enabled && searchEngines.length === 1;
           return (
-            <MenuItem
-              as="button"
+            <button
+              type="button"
               disabled={isLast}
               key={item.value}
               className={clsx(
@@ -188,10 +191,10 @@ export default function SettingsButton(props: SettingsButtonProps) {
               {enabled && (
                 <CheckCircleIcon className="flex-none ml-auto size-5" />
               )}
-            </MenuItem>
+            </button>
           );
         })}
-      </MenuItems>
-    </Menu>
+      </PopoverPanel>
+    </Popover>
   );
 }

--- a/src/features/settings/components/SettingsButton/SettingsButton.tsx
+++ b/src/features/settings/components/SettingsButton/SettingsButton.tsx
@@ -1,6 +1,7 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import Cog6ToothIcon from "@heroicons/react/16/solid/Cog6ToothIcon";
 import ComputerDesktopIcon from "@heroicons/react/16/solid/ComputerDesktopIcon";
+import GlobeAltIcon from "@heroicons/react/16/solid/GlobeAltIcon";
 import MoonIcon from "@heroicons/react/16/solid/MoonIcon";
 import RectangleGroupIcon from "@heroicons/react/16/solid/RectangleGroupIcon";
 import Squares2X2Icon from "@heroicons/react/16/solid/Squares2X2Icon";
@@ -8,10 +9,15 @@ import SunIcon from "@heroicons/react/16/solid/SunIcon";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import clsx from "clsx";
 import { useCallback, useContext } from "react";
+import useSearchEngines from "@/features/settings/hooks/useSearchEngine";
 import useViewMode from "@/features/settings/hooks/useViewMode";
 import { ThemeContext } from "@/features/theme/context/ThemeProvider";
 import { MessageType } from "@/services/runtime/types";
-import type { ThemeValue, ViewModeValue } from "@/services/storage/types";
+import type {
+  SearchEngineValue,
+  ThemeValue,
+  ViewModeValue,
+} from "@/services/storage/types";
 import { defaultClassName } from "@/shared/components/ButtonItem/ButtonItem";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 
@@ -43,6 +49,7 @@ export default function SettingsButton(props: SettingsButtonProps) {
   const { t } = useTranslation();
   const { theme, setTheme } = useContext(ThemeContext);
   const { viewMode, setViewMode } = useViewMode();
+  const { searchEngines, toggleSearchEngine } = useSearchEngines();
 
   const handleViewModeChange = useCallback(
     async (value: ViewModeValue) => {
@@ -89,6 +96,16 @@ export default function SettingsButton(props: SettingsButtonProps) {
   const modes: { value: ViewModeValue; label: string }[] = [
     { value: "popup", label: t("viewMode.popup") },
     { value: "sidepanel", label: t("viewMode.sidepanel") },
+  ];
+
+  const engines: { value: SearchEngineValue; label: string }[] = [
+    { value: "google", label: t("searchEngines.google") },
+    { value: "bing", label: t("searchEngines.bing") },
+    { value: "duckduckgo", label: t("searchEngines.duckduckgo") },
+    { value: "brave", label: t("searchEngines.brave") },
+    { value: "ecosia", label: t("searchEngines.ecosia") },
+    { value: "yahoo_japan", label: t("searchEngines.yahoo_japan") },
+    { value: "perplexity", label: t("searchEngines.perplexity") },
   ];
 
   return (
@@ -145,6 +162,35 @@ export default function SettingsButton(props: SettingsButtonProps) {
             )}
           </MenuItem>
         ))}
+        <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
+        <div className="px-3 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          {t("settings.searchEngine")}
+        </div>
+        {engines.map((item) => {
+          const enabled = searchEngines.includes(item.value);
+          const isLast = enabled && searchEngines.length === 1;
+          return (
+            <MenuItem
+              as="button"
+              disabled={isLast}
+              key={item.value}
+              className={clsx(
+                "flex items-center w-full px-3 py-2 space-x-2 hover:cursor-pointer hover:bg-gray-400 hover:opacity-80 dark:hover:bg-gray-700",
+                enabled
+                  ? "text-gray-800 dark:text-gray-300"
+                  : "text-gray-400 dark:text-gray-500",
+                isLast && "opacity-50 cursor-not-allowed",
+              )}
+              onClick={() => toggleSearchEngine(item.value)}
+            >
+              <GlobeAltIcon className="size-5" />
+              <div className="min-w-24">{item.label}</div>
+              {enabled && (
+                <CheckCircleIcon className="flex-none ml-auto size-5" />
+              )}
+            </MenuItem>
+          );
+        })}
       </MenuItems>
     </Menu>
   );

--- a/src/features/settings/hooks/useSearchEngine.ts
+++ b/src/features/settings/hooks/useSearchEngine.ts
@@ -1,0 +1,79 @@
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  getDefaultSearchEngines,
+  isValidSearchEngines,
+  type SearchEngineValue,
+  SyncStorageKey,
+  storageService,
+} from "@/services/storage";
+
+const listeners = new Set<() => void>();
+
+let snapshot: SearchEngineValue[] = getDefaultSearchEngines();
+
+const notify = () => {
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+const updateSnapshot = (engines: SearchEngineValue[]) => {
+  snapshot = engines;
+  notify();
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = () => snapshot;
+
+const hydrateSearchEngines = async () => {
+  try {
+    const stored = await storageService.getSearchEngines();
+    updateSnapshot(
+      isValidSearchEngines(stored) ? stored : getDefaultSearchEngines(),
+    );
+  } catch (error) {
+    console.error("Failed to hydrate searchEngines", error);
+    updateSnapshot(getDefaultSearchEngines());
+  }
+};
+
+storageService.subscribe(SyncStorageKey.SearchEngines, (newEngines) => {
+  updateSnapshot(
+    isValidSearchEngines(newEngines) ? newEngines : getDefaultSearchEngines(),
+  );
+});
+
+void hydrateSearchEngines();
+
+export default function useSearchEngines() {
+  const searchEngines = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
+
+  const setSearchEngines = useCallback((engines: SearchEngineValue[]) => {
+    if (engines.length === 0) return;
+    updateSnapshot(engines);
+    storageService.setSearchEngines(engines).catch((error) => {
+      console.error("Failed to persist searchEngines", error);
+    });
+  }, []);
+
+  const toggleSearchEngine = useCallback(
+    (engine: SearchEngineValue) => {
+      const next = searchEngines.includes(engine)
+        ? searchEngines.filter((e) => e !== engine)
+        : [...searchEngines, engine];
+      if (next.length === 0) return; // 最低1つは有効
+      setSearchEngines(next);
+    },
+    [searchEngines, setSearchEngines],
+  );
+
+  return { searchEngines, toggleSearchEngine };
+}

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -49,6 +49,10 @@ storageService.subscribe(SyncStorageKey.SearchEngines, (newEngines) => {
 
 void hydrateSearchEngines();
 
+/**
+ * 有効な検索エンジン一覧を取得し、トグル操作を提供するフック。
+ * Chrome Storage と同期し、変更は即座に UI へ反映される。
+ */
 export default function useSearchEngines() {
   const searchEngines = useSyncExternalStore(
     subscribe,
@@ -58,9 +62,11 @@ export default function useSearchEngines() {
 
   const setSearchEngines = useCallback((engines: SearchEngineValue[]) => {
     if (engines.length === 0) return;
+    const previous = snapshot;
     updateSnapshot(engines);
     storageService.setSearchEngines(engines).catch((error) => {
       console.error("Failed to persist searchEngines", error);
+      updateSnapshot(previous);
     });
   }, []);
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,6 +33,7 @@
     "title": "Settings",
     "theme": "Theme",
     "viewMode": "View Mode",
+    "searchEngine": "Search Engine",
     "open": "Open settings"
   },
   "language": {
@@ -44,7 +45,9 @@
     "bing": "Bing",
     "duckduckgo": "DuckDuckGo",
     "brave": "Brave",
-    "ecosia": "Ecosia"
+    "ecosia": "Ecosia",
+    "yahoo_japan": "Yahoo! Japan",
+    "perplexity": "Perplexity"
   },
   "accessibility": {
     "favicon": "Favicon"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -33,6 +33,7 @@
     "title": "設定",
     "theme": "テーマ",
     "viewMode": "表示モード",
+    "searchEngine": "検索エンジン",
     "open": "設定を開く"
   },
   "language": {
@@ -44,7 +45,9 @@
     "bing": "Bing",
     "duckduckgo": "DuckDuckGo",
     "brave": "Brave",
-    "ecosia": "Ecosia"
+    "ecosia": "Ecosia",
+    "yahoo_japan": "Yahoo! Japan",
+    "perplexity": "Perplexity"
   },
   "accessibility": {
     "favicon": "ファビコン"

--- a/src/services/result/helper.ts
+++ b/src/services/result/helper.ts
@@ -17,6 +17,12 @@ export const calSingleCount = (
   return Math.floor(count / serviceCount);
 };
 
+/** カタカナをひらがなに変換（ひらがな・カタカナ混在クエリの検索精度向上） */
+const normalizeKana = (str: string): string =>
+  str.replace(/[\u30A1-\u30F6]/g, (ch) =>
+    String.fromCharCode(ch.charCodeAt(0) - 0x60),
+  );
+
 export const fuseSearch = (
   query: string,
   result: Result<Kind>[],
@@ -24,6 +30,15 @@ export const fuseSearch = (
   const fuse = new Fuse(result, {
     keys: ["title", "url"],
     threshold: 0.4,
+    ignoreLocation: true,
+    getFn: (obj, path) => {
+      const val = Fuse.config.getFn(obj, path);
+      if (typeof val === "string") return normalizeKana(val);
+      if (Array.isArray(val))
+        return val.map((v) => (typeof v === "string" ? normalizeKana(v) : v));
+      return val;
+    },
   });
-  return fuse.search(query).map((res) => res.item);
+
+  return fuse.search(normalizeKana(query)).map((res) => res.item);
 };

--- a/src/services/result/service.ts
+++ b/src/services/result/service.ts
@@ -2,6 +2,7 @@
  * Result Service - Result管理サービス
  */
 
+import { getDefaultSearchEngines } from "@/services/storage/helper";
 import resultServiceDependencies from "./container";
 import * as Helper from "./helper";
 import type * as Type from "./types";
@@ -65,7 +66,7 @@ const queryResults = async (
   if (filters.categories.includes("Suggestion")) {
     const engines = filters.searchEngines?.length
       ? filters.searchEngines
-      : ["google" as const];
+      : getDefaultSearchEngines();
     queryPromises.push(
       resultServiceDependencies.suggestionService
         .multiEngineQuery({

--- a/src/services/result/service.ts
+++ b/src/services/result/service.ts
@@ -63,10 +63,14 @@ const queryResults = async (
   }
 
   if (filters.categories.includes("Suggestion")) {
+    const engines = filters.searchEngines?.length
+      ? filters.searchEngines
+      : ["google" as const];
     queryPromises.push(
       resultServiceDependencies.suggestionService
-        .query({
+        .multiEngineQuery({
           query: filters?.query ?? "",
+          searchEngines: engines,
           option: { count },
         })
         .then((result) => ({ service: "Suggestion", data: result }) as const),

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -5,6 +5,7 @@
 import type { Action, Kind as ActionKind } from "@/services/action/types";
 import type { Bookmark } from "@/services/bookmark/types";
 import type { History } from "@/services/history/types";
+import type { SearchEngineValue } from "@/services/storage/types";
 import type { Suggestion } from "@/services/suggestion/types";
 import type { Tab } from "@/services/tab/types";
 
@@ -66,4 +67,5 @@ export interface ResultFilters {
   query?: string;
   count?: number;
   categories: Kind[];
+  searchEngines?: SearchEngineValue[];
 }

--- a/src/services/storage/helper.ts
+++ b/src/services/storage/helper.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  SearchEngineValue,
   SyncStorage,
   SyncStorageKey,
   ThemeValue,
@@ -65,6 +66,41 @@ export const getDefaultViewMode = (): ViewModeValue => "popup";
  */
 export const isValidViewMode = (value: unknown): value is ViewModeValue => {
   return ["popup", "sidepanel"].includes(value as string);
+};
+
+const VALID_SEARCH_ENGINES: SearchEngineValue[] = [
+  "google",
+  "bing",
+  "duckduckgo",
+  "brave",
+  "ecosia",
+  "yahoo_japan",
+  "perplexity",
+];
+
+/**
+ * デフォルト有効検索エンジン一覧を取得
+ */
+export const getDefaultSearchEngines = (): SearchEngineValue[] => ["google"];
+
+/**
+ * 検索エンジン値のバリデーション（単体）
+ */
+export const isValidSearchEngine = (
+  value: unknown,
+): value is SearchEngineValue => {
+  return VALID_SEARCH_ENGINES.includes(value as SearchEngineValue);
+};
+
+/**
+ * 検索エンジン配列のバリデーション
+ */
+export const isValidSearchEngines = (
+  value: unknown,
+): value is SearchEngineValue[] => {
+  return (
+    Array.isArray(value) && value.length > 0 && value.every(isValidSearchEngine)
+  );
 };
 
 /**

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -6,8 +6,10 @@
 import {
   chromeStorageGet,
   chromeStorageSet,
+  getDefaultSearchEngines,
   getDefaultTheme,
   getDefaultViewMode,
+  isValidSearchEngines,
   isValidViewMode,
 } from "./helper";
 import type * as Type from "./types";
@@ -29,6 +31,8 @@ export interface StorageService {
   setTheme: (request: Type.SetThemeRequest) => Promise<boolean>;
   getViewMode: () => Promise<Type.ViewModeValue>;
   setViewMode: (viewMode: Type.ViewModeValue) => Promise<boolean>;
+  getSearchEngines: () => Promise<Type.SearchEngineValue[]>;
+  setSearchEngines: (engines: Type.SearchEngineValue[]) => Promise<boolean>;
 }
 
 // サービス実装
@@ -122,6 +126,31 @@ const setViewMode = async (viewMode: Type.ViewModeValue): Promise<boolean> => {
   }
 };
 
+const getSearchEngines = async (): Promise<Type.SearchEngineValue[]> => {
+  try {
+    const engines = await chromeStorageGet(SyncStorageKey.SearchEngines);
+    return isValidSearchEngines(engines) ? engines : getDefaultSearchEngines();
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[storageService] getSearchEngines failed:", error);
+    }
+    return getDefaultSearchEngines();
+  }
+};
+
+const setSearchEngines = async (
+  engines: Type.SearchEngineValue[],
+): Promise<boolean> => {
+  try {
+    return await chromeStorageSet(SyncStorageKey.SearchEngines, engines);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[storageService] setSearchEngines failed:", error);
+    }
+    throw new Error("検索エンジンの保存に失敗しました");
+  }
+};
+
 // サービスオブジェクトのエクスポート
 export const storageService: StorageService = {
   get: getStorage,
@@ -131,6 +160,8 @@ export const storageService: StorageService = {
   setTheme,
   getViewMode,
   setViewMode,
+  getSearchEngines,
+  setSearchEngines,
 };
 
 // デフォルトエクスポート

--- a/src/services/storage/types.ts
+++ b/src/services/storage/types.ts
@@ -5,14 +5,24 @@
 export enum SyncStorageKey {
   Theme = "theme",
   ViewMode = "viewMode",
+  SearchEngines = "searchEngines",
 }
 
 export type ThemeValue = "light" | "dark" | "system";
 export type ViewModeValue = "popup" | "sidepanel";
+export type SearchEngineValue =
+  | "google"
+  | "bing"
+  | "duckduckgo"
+  | "brave"
+  | "ecosia"
+  | "yahoo_japan"
+  | "perplexity";
 
 export interface SyncStorage {
   [SyncStorageKey.Theme]: ThemeValue;
   [SyncStorageKey.ViewMode]: ViewModeValue;
+  [SyncStorageKey.SearchEngines]: SearchEngineValue[];
 }
 
 // リクエスト型定義

--- a/src/services/suggestion/converter.ts
+++ b/src/services/suggestion/converter.ts
@@ -1,37 +1,40 @@
 /**
- * Suggestion Converter - Google APIレスポンスをSuggestion型に変換
+ * Suggestion Converter - APIレスポンスをSuggestion型に変換
  */
 
+import type { SearchEngineValue } from "@/services/storage/types";
+import { buildSearchUrl } from "./helper";
 import type { Suggestion } from "./types";
 
-const SEARCH_URL = "https://www.google.com/search";
+type SearchKind = Suggestion["data"]["type"];
+
+const ENGINE_TO_KIND: Record<SearchEngineValue, SearchKind> = {
+  google: "Google",
+  bing: "Bing",
+  duckduckgo: "DuckDuckGo",
+  brave: "Brave",
+  ecosia: "Ecosia",
+  yahoo_japan: "Yahoo Japan",
+  perplexity: "Perplexity",
+};
 
 export function convertSuggestions(
   suggestion: string,
   originalQuery: string,
+  engine: SearchEngineValue = "google",
 ): Suggestion {
+  const url = buildSearchUrl(suggestion, engine);
   return {
     id: crypto.randomUUID(),
     type: "Suggestion",
     title: suggestion,
-    url: createSearchUrl(suggestion),
+    url,
     data: {
-      type: "Google",
-      suggestion: suggestion,
+      type: ENGINE_TO_KIND[engine],
+      suggestion,
       title: suggestion,
-      url: createSearchUrl(suggestion),
+      url,
       query: originalQuery,
     },
   };
-}
-
-/**
- * 検索URLを作成（URLの場合はそのまま、検索クエリの場合はGoogle検索URL）
- */
-function createSearchUrl(query: string): string {
-  if (/^https?:\/\//i.test(query)) {
-    return query;
-  }
-
-  return `${SEARCH_URL}?q=${encodeURIComponent(query)}`;
 }

--- a/src/services/suggestion/helper.ts
+++ b/src/services/suggestion/helper.ts
@@ -78,23 +78,12 @@ export const extractYahooJapanSuggestions = (data: unknown): string[] => {
   return hit
     .filter(
       (h): h is { Key: string } =>
-        typeof h === "object" && h !== null && "Key" in h,
+        typeof h === "object" &&
+        h !== null &&
+        "Key" in h &&
+        typeof (h as { Key: unknown }).Key === "string",
     )
     .map((h) => h.Key);
-};
-
-/**
- * Google サジェスト形式からテキストを抽出
- * 形式: ["query", [["suggestion1", 0], ["suggestion2", 0], ...], ...]
- */
-export const extractGoogleSuggestions = (data: unknown): string[] => {
-  if (!Array.isArray(data) || !Array.isArray(data[1])) return [];
-  return (data[1] as unknown[])
-    .filter(
-      (item): item is [string, ...unknown[]] =>
-        Array.isArray(item) && typeof item[0] === "string",
-    )
-    .map((item) => item[0]);
 };
 
 /**

--- a/src/services/suggestion/helper.ts
+++ b/src/services/suggestion/helper.ts
@@ -1,7 +1,8 @@
 /**
- * Suggestion Helper - Google検索候補関連のヘルパー関数
+ * Suggestion Helper - 検索候補関連のヘルパー関数
  */
 
+import type { SearchEngineValue } from "@/services/storage/types";
 import type { Suggestion } from "./types";
 
 /**
@@ -13,29 +14,97 @@ export const limitResults =
     return count ? suggestions.slice(0, count) : suggestions;
   };
 
-/**
- * Google Suggest APIのエンドポイントURLを構築
- */
-export const buildSuggestUrl = (query: string): string => {
-  const keyword = encodeURIComponent(query.trim());
-  return `https://www.google.com/complete/search?client=chrome&q=${keyword}`;
+// サジェストAPIのURL。対応APIがないエンジンは空文字を返す
+const SUGGEST_URLS: Record<SearchEngineValue, (q: string) => string> = {
+  google: (q) => `https://www.google.com/complete/search?client=firefox&q=${q}`,
+  bing: (q) => `https://api.bing.com/osjson.aspx?query=${q}`,
+  duckduckgo: (q) => `https://ac.duckduckgo.com/ac/?q=${q}&type=list`,
+  brave: (q) => `https://search.brave.com/api/suggest?q=${q}`,
+  ecosia: (q) => `https://ac.ecosia.org/autocomplete?q=${q}&type=list`,
+  yahoo_japan: (q) => `https://search.yahoo.co.jp/sugg/ss?p=${q}&output=json`,
+  perplexity: () => "",
+};
+
+// 検索URLビルダー。エンジンごとにクエリパラメータ名が異なる場合に対応
+const SEARCH_URLS: Record<SearchEngineValue, (q: string) => string> = {
+  google: (q) => `https://www.google.com/search?q=${q}`,
+  bing: (q) => `https://www.bing.com/search?q=${q}`,
+  duckduckgo: (q) => `https://duckduckgo.com/?q=${q}`,
+  brave: (q) => `https://search.brave.com/search?q=${q}`,
+  ecosia: (q) => `https://www.ecosia.org/search?q=${q}`,
+  yahoo_japan: (q) => `https://search.yahoo.co.jp/search?p=${q}`,
+  perplexity: (q) => `https://www.perplexity.ai/search?q=${q}`,
 };
 
 /**
- * APIレスポンスからサジェスチョンリストを抽出
+ * 検索エンジンのSuggest APIエンドポイントURLを構築。
+ * 対応APIがないエンジンは空文字を返す。
  */
-export const extractSuggestions = (data: unknown): string[] => {
-  if (Array.isArray(data) && Array.isArray(data[0])) {
-    // 各サジェスト項目から文字列部分（インデックス0）を抽出
-    return data[0]
-      .filter(
-        (item: unknown) => Array.isArray(item) && typeof item[0] === "string",
-      )
-      .map((item: unknown[]) => item[0] as string);
-  }
+export const buildSuggestUrl = (
+  query: string,
+  engine: SearchEngineValue = "google",
+): string => {
+  const keyword = encodeURIComponent(query.trim());
+  return SUGGEST_URLS[engine](keyword);
+};
 
-  if (!Array.isArray(data) || !Array.isArray(data[1])) {
+/**
+ * 検索エンジンの検索URLを構築
+ */
+export const buildSearchUrl = (
+  query: string,
+  engine: SearchEngineValue = "google",
+): string => {
+  if (/^https?:\/\//i.test(query)) {
+    return query;
+  }
+  return SEARCH_URLS[engine](encodeURIComponent(query));
+};
+
+/**
+ * Yahoo Japan サジェストAPIレスポンスからサジェスチョンリストを抽出
+ * レスポンス形式: {"Result":{"Query":"...","Hit":[{"Key":"..."},...]}}
+ */
+export const extractYahooJapanSuggestions = (data: unknown): string[] => {
+  if (typeof data !== "object" || data === null || !("Result" in data)) {
     return [];
   }
-  return data[1] as string[];
+  const result = (data as { Result: unknown }).Result;
+  if (typeof result !== "object" || result === null || !("Hit" in result)) {
+    return [];
+  }
+  const hit = (result as { Hit: unknown }).Hit;
+  if (!Array.isArray(hit)) return [];
+  return hit
+    .filter(
+      (h): h is { Key: string } =>
+        typeof h === "object" && h !== null && "Key" in h,
+    )
+    .map((h) => h.Key);
+};
+
+/**
+ * Google サジェスト形式からテキストを抽出
+ * 形式: ["query", [["suggestion1", 0], ["suggestion2", 0], ...], ...]
+ */
+export const extractGoogleSuggestions = (data: unknown): string[] => {
+  if (!Array.isArray(data) || !Array.isArray(data[1])) return [];
+  return (data[1] as unknown[])
+    .filter(
+      (item): item is [string, ...unknown[]] =>
+        Array.isArray(item) && typeof item[0] === "string",
+    )
+    .map((item) => item[0]);
+};
+
+/**
+ * 標準 OpenSearch 形式からテキストを抽出
+ * 形式: ["query", ["suggestion1", "suggestion2", ...]]
+ */
+export const extractSuggestions = (data: unknown): string[] => {
+  if (!Array.isArray(data) || !Array.isArray(data[1])) return [];
+
+  return (data[1] as unknown[]).filter(
+    (s): s is string => typeof s === "string",
+  );
 };

--- a/src/services/suggestion/service.ts
+++ b/src/services/suggestion/service.ts
@@ -34,21 +34,23 @@ const fetchApiSuggestions = async (
   if (!endpoint) return [];
 
   try {
-    const response = await fetch(endpoint);
+    const response = await fetch(endpoint, {
+      signal: AbortSignal.timeout(3000),
+    });
 
     if (!response.ok) return [];
 
-    const text = await response.text();
+    const data = JSON.parse(await response.text());
 
     if (engine === "yahoo_japan") {
-      return extractYahooJapanSuggestions(JSON.parse(text));
+      return extractYahooJapanSuggestions(data);
     }
 
     // Google (client=firefox) および Bing・DDG 等はすべて
     // ["query", ["s1", "s2", ...]] の plain JSON 形式
-    return extractSuggestions(JSON.parse(text));
-  } catch {
-    console.error("Error fetching suggestions:", { query, engine, endpoint });
+    return extractSuggestions(data);
+  } catch (error) {
+    console.error("Error fetching suggestions:", { query, engine, endpoint, error });
 
     return [];
   }

--- a/src/services/suggestion/service.ts
+++ b/src/services/suggestion/service.ts
@@ -1,62 +1,139 @@
 /**
- * Suggestion Service - マイクロサービス形式のGoogle検索候補管理サービス
- * 責任: Google検索候補の取得を担当
+ * Suggestion Service - 検索候補管理サービス
+ * 責任: 各検索エンジンの候補取得を担当
  */
 
+import type { SearchEngineValue } from "@/services/storage/types";
 import { convertSuggestions } from "./converter";
-import { buildSuggestUrl, extractSuggestions, limitResults } from "./helper";
+import {
+  buildSearchUrl,
+  buildSuggestUrl,
+  extractSuggestions,
+  extractYahooJapanSuggestions,
+  limitResults,
+} from "./helper";
 import type * as Type from "./types";
 
 // 型定義
 export interface SuggestionService {
   query: (request: Type.QuerySuggestionsRequest) => Promise<Type.Suggestion[]>;
+  multiEngineQuery: (
+    request: Type.MultiEngineQuerySuggestionsRequest,
+  ) => Promise<Type.Suggestion[]>;
 }
-const querySuggestions = async ({
-  query,
-  option,
-}: Type.QuerySuggestionsRequest): Promise<Type.Suggestion[]> => {
-  if (!query?.trim()) {
-    return [];
-  }
+
+/**
+ * 検索エンジン API からサジェストテキストのみを取得する。
+ * 失敗した場合は空配列を返す（raw query のフォールバックは含まない）。
+ */
+const fetchApiSuggestions = async (
+  query: string,
+  engine: SearchEngineValue,
+): Promise<string[]> => {
+  const endpoint = buildSuggestUrl(query, engine);
+  if (!endpoint) return [];
 
   try {
-    const endpoint = buildSuggestUrl(query);
-    const response = await fetch(endpoint, {
-      // mode: "cors",
-    });
+    const response = await fetch(endpoint);
 
-    if (!response.ok) {
-      console.error("Failed to fetch Google suggestions:", response.statusText);
-      // エラー時は元のクエリのみ返す
-      return [convertSuggestions(query, query)];
-    }
+    if (!response.ok) return [];
 
     const text = await response.text();
 
-    const match = text.match(/window\.google\.ac\.h\((\[.*?\])\)/);
-    if (!match) {
-      throw new Error("Invalid JSONP response format");
+    if (engine === "yahoo_japan") {
+      return extractYahooJapanSuggestions(JSON.parse(text));
     }
 
-    const data = JSON.parse(match[1]);
-    const suggestions = extractSuggestions(data);
+    // Google (client=firefox) および Bing・DDG 等はすべて
+    // ["query", ["s1", "s2", ...]] の plain JSON 形式
+    return extractSuggestions(JSON.parse(text));
+  } catch {
+    console.error("Error fetching suggestions:", { query, engine, endpoint });
 
-    const result = [
-      convertSuggestions(query, query),
-      ...suggestions.map((title) => convertSuggestions(title, query)),
-    ];
-
-    return limitResults(option?.count)(result) as Type.Suggestion[];
-  } catch (error) {
-    console.error("Error fetching Google suggestions:", error);
-    // エラー時は元のクエリのみ返す
-    return [convertSuggestions(query, query)];
+    return [];
   }
+};
+
+/**
+ * クエリをそのまま「直接検索」するサジェストアイテムを生成する。
+ * URL はそのエンジンの検索 URL。
+ */
+const buildDirectSearch = (
+  query: string,
+  engine: SearchEngineValue,
+): Type.Suggestion => {
+  const url = buildSearchUrl(query, engine);
+
+  return {
+    id: crypto.randomUUID(),
+    type: "Suggestion",
+    title: query,
+    url,
+    data: convertSuggestions(query, query, engine).data,
+  };
+};
+
+/**
+ * 単一エンジン向けクエリ: 直接検索 + API サジェスト
+ */
+const querySuggestions = async ({
+  query,
+  option,
+  searchEngine = "google",
+}: Type.QuerySuggestionsRequest): Promise<Type.Suggestion[]> => {
+  if (!query?.trim()) return [];
+
+  const texts = await fetchApiSuggestions(query, searchEngine);
+
+  const result = [
+    buildDirectSearch(query, searchEngine),
+    ...texts.map((title) => convertSuggestions(title, query, searchEngine)),
+  ];
+  return limitResults(option?.count)(result) as Type.Suggestion[];
+};
+
+/**
+ * 複数エンジン向けクエリ:
+ * - 直接検索アイテムを各エンジン分生成（URL が異なるため重複排除しない）
+ * - API サジェストはエンジン横断でタイトル重複排除して結合
+ */
+const multiEngineQuerySuggestions = async ({
+  query,
+  option,
+  searchEngines,
+}: Type.MultiEngineQuerySuggestionsRequest): Promise<Type.Suggestion[]> => {
+  if (!query?.trim()) return [];
+
+  const directSearchItems = searchEngines.map((e) =>
+    buildDirectSearch(query, e),
+  );
+
+  const apiResultsPerEngine = await Promise.all(
+    searchEngines.map((e) => fetchApiSuggestions(query, e)),
+  );
+
+  const seenTitles = new Set<string>([query]); // 直接検索と同タイトルは除外
+  const apiSuggestions: Type.Suggestion[] = [];
+  for (const [i, texts] of apiResultsPerEngine.entries()) {
+    const engine = searchEngines[i];
+    for (const title of texts) {
+      if (!seenTitles.has(title)) {
+        seenTitles.add(title);
+        apiSuggestions.push(convertSuggestions(title, query, engine));
+      }
+    }
+  }
+
+  return limitResults(option?.count)([
+    ...directSearchItems,
+    ...apiSuggestions,
+  ]) as Type.Suggestion[];
 };
 
 // サービスオブジェクトのエクスポート
 export const suggestionService: SuggestionService = {
   query: querySuggestions,
+  multiEngineQuery: multiEngineQuerySuggestions,
 };
 
 // デフォルトエクスポート

--- a/src/services/suggestion/types.ts
+++ b/src/services/suggestion/types.ts
@@ -2,7 +2,16 @@
  * Suggestion Service Types - Google検索候補関連の型定義
  */
 
-type SearchKind = "Google" | "Bing" | "DuckDuckGo" | "Brave" | "Ecosia";
+import type { SearchEngineValue } from "@/services/storage/types";
+
+type SearchKind =
+  | "Google"
+  | "Bing"
+  | "DuckDuckGo"
+  | "Brave"
+  | "Ecosia"
+  | "Yahoo Japan"
+  | "Perplexity";
 
 export interface Suggestion {
   id: string;
@@ -21,6 +30,13 @@ export interface Suggestion {
 export interface QuerySuggestionsRequest {
   query: string;
   option?: QueryOption;
+  searchEngine?: SearchEngineValue;
+}
+
+export interface MultiEngineQuerySuggestionsRequest {
+  query: string;
+  option?: QueryOption;
+  searchEngines: SearchEngineValue[];
 }
 
 export interface QueryOption {

--- a/src/services/suggestion/types.ts
+++ b/src/services/suggestion/types.ts
@@ -1,5 +1,5 @@
 /**
- * Suggestion Service Types - Google検索候補関連の型定義
+ * Suggestion Service Types - 検索候補関連の型定義
  */
 
 import type { SearchEngineValue } from "@/services/storage/types";

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -20,6 +20,14 @@ export default defineConfig({
     description: "Search your bookmarks and history",
     version: "1.6.1",
     permissions: ["tabs", "history", "activeTab", "bookmarks", "storage", "sidePanel"],
+    host_permissions: [
+      "https://www.google.com/complete/*",
+      "https://api.bing.com/*",
+      "https://ac.duckduckgo.com/*",
+      "https://search.brave.com/api/*",
+      "https://ac.ecosia.org/*",
+      "https://search.yahoo.co.jp/sugg/*",
+    ],
     commands: {
       OPEN_POPUP: {
         suggested_key: {


### PR DESCRIPTION
## Summary

- 検索エンジンを複数 ON/OFF できるトグル UI を追加（Google / Bing / DuckDuckGo / Brave / Ecosia / Yahoo Japan / Perplexity）
- 複数エンジンの Suggest API を並列取得し、タイトル重複排除して結合
- Fuse.js パイプラインから Suggestion を分離（API 側が関連度フィルタ済みのため）
- ひらがな・カタカナ混在クエリの検索精度を改善（カタカナ→ひらがな正規化）

## Changes

- **storage**: `SearchEngines` キーと `SearchEngineValue` 型を追加
- **suggestion service**: `multiEngineQuery` を追加、Google を `client=firefox` に変更（plain JSON）
- **result service**: `reduce` 時点で Suggestion / others を分離
- **result helper**: `fuseSearch` に `ignoreLocation` + カタカナ正規化を追加
- **manifest**: 各 Suggest API ドメインの `host_permissions` を追加
- **useSearchEngines**: `useSyncExternalStore` パターンで永続化
- **i18n**: Yahoo Japan / Perplexity のキーを追加

## Related

- Closes #155 (UI ブラッシュアップは別 issue へ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# 検索エンジン切り替え機能の実装（マルチセレクトトグル）

## 概要
複数の検索エンジン（Google、Bing、DuckDuckGo、Brave、Ecosia、Yahoo Japan、Perplexity）のON/OFF切り替えができるトグルUI機能を実装しました。複数エンジンからの並列提案取得、重複排除、結果統合を実現します。

## 主な変更内容

### 機能実装
- **マルチエンジン対応提案機能**：`suggestionService.multiEngineQuery()` を新規追加。複数エンジンから並列で提案APIを取得し、タイトル別に重複排除してマージします
- **検索精度向上**：ひらがな・カタカナ混在クエリの正規化に対応。`normalizeKana()` を実装し、Fuse.jsの検索精度を改善
- **提案フロー分離**：提案結果をFuse.jsパイプラインから分離。API応答は既に関連度フィルタリング済みと仮定

### ストレージ・永続化
- **新しいストレージキー**：`SyncStorageKey.SearchEngines` を追加（型: `SearchEngineValue[]`）
- **ストレージサービス**：`getSearchEngines()`・`setSearchEngines()` メソッドを実装
- **データ検証**：`isValidSearchEngine()`・`isValidSearchEngines()` 型ガード関数を追加

### UI・コンポーネント
- **SettingsButton拡張**：検索エンジン選択セクションを追加。有効エンジンの表示・切り替え・最後のエンジンの無効化防止に対応
- **SearchApp連携**：`useSearchEngines()` フックから取得したエンジン選択を `useSearchResults` に渡す

### フック・状態管理
- **useSearchEngines フック**：`useSyncExternalStore` を用いた新規フック実装。`searchEngines` 状態と `toggleSearchEngine()` アクションを提供。ストレージとの双方向同期、エラー時の自動リバート機能を備えます

### API・サービス層
- **提案サービス汎用化**：Google専用JSONP形式から複数エンジン対応へ変更
  - エンジン別ヘッダー・パース処理の実装（Yahoo Japanは専用パーサー `extractYahooJapanSuggestions()` を使用）
  - `buildSuggestUrl()`・`buildSearchUrl()` に engine パラメータを追加
- **結果サービス**：Suggestion vs. その他を分離処理。`fuseSearch` に `ignoreLocation: true` オプションとKana正規化を追加
- **リクエスト型拡張**：`UseSearchResultsParams`・`ResultFilters` に `searchEngines` フィールドを追加

### 設定・マニフェスト
- **ホストパーミッション追加**：各検索エンジンの提案API域に対応（Google、Bing、DuckDuckGo、Brave、Ecosia、Yahoo Japan）
- **多言語対応**：`ui.settings.searchEngine`、`searchEngines.yahoo_japan`、`searchEngines.perplexity` のi18nキーを追加（英語・日本語対応）

## 技術的ポイント
- キャッシュキー生成：`${query}::${categories}::${searchEnginesSegment}` 形式に拡張
- エラーハンドリング：ストレージ永続化失敗時はスナップショットを自動リバート
- 並列フェッチ：`AbortSignal.timeout(3000)` で提案リクエストのタイムアウト制御
- 型安全性：`SearchEngineValue` ユニオン型で全エンジン定義を集約

## 関連課題
- #155 の UI ポーランド関連項目（ファビコン表示、ドラッグ&ドロップ、ツールチップ等）は別途対応予定
<!-- end of auto-generated comment: release notes by coderabbit.ai -->