### PR TITLE
feat: AbortController for suggestion cancellation + cache invalidation (#131, #122)

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,3 +1,7 @@
+import {
+  type InvalidateCacheKind,
+  MessageType,
+} from "@/services/runtime/types";
 import { storageService } from "@/services/storage";
 import { SyncStorageKey, type ViewModeValue } from "@/services/storage/types";
 import { routeCommand, routeMessage } from "./router";
@@ -9,6 +13,18 @@ let cachedViewMode: ViewModeValue = "popup";
 // サイドパネルの開閉状態をポート接続で追跡する
 // ポートが存在する = サイドパネルが開いている
 let sidePanelPort: chrome.runtime.Port | null = null;
+
+/**
+ * ポップアップ・サイドパネルへキャッシュ無効化メッセージを送信する。
+ * 拡張機能ページが開いていない場合は無視する。
+ */
+const broadcastInvalidateCache = (kind: InvalidateCacheKind) => {
+  chrome.runtime
+    .sendMessage({ type: MessageType.INVALIDATE_CACHE, kind })
+    .catch(() => {
+      // ポップアップが開いていない場合は "Receiving end does not exist" になるが正常系
+    });
+};
 
 export default defineBackground(() => {
   const updateViewMode = (viewMode: ViewModeValue) => {
@@ -38,6 +54,24 @@ export default defineBackground(() => {
       });
     }
   });
+
+  // タブの変更をキャッシュ無効化に反映する
+  chrome.tabs.onCreated.addListener(() => broadcastInvalidateCache("Tab"));
+  chrome.tabs.onRemoved.addListener(() => broadcastInvalidateCache("Tab"));
+  chrome.tabs.onUpdated.addListener((_id, info) => {
+    if (info.status === "complete") broadcastInvalidateCache("Tab");
+  });
+
+  // ブックマークの変更をキャッシュ無効化に反映する
+  chrome.bookmarks.onCreated.addListener(() =>
+    broadcastInvalidateCache("Bookmark"),
+  );
+  chrome.bookmarks.onRemoved.addListener(() =>
+    broadcastInvalidateCache("Bookmark"),
+  );
+  chrome.bookmarks.onChanged.addListener(() =>
+    broadcastInvalidateCache("Bookmark"),
+  );
 
   /**
    * @description コマンドのルーティング

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -73,6 +73,14 @@ export default defineBackground(() => {
     broadcastInvalidateCache("Bookmark"),
   );
 
+  // 履歴の変更をキャッシュ無効化に反映する
+  chrome.history.onVisited.addListener(() =>
+    broadcastInvalidateCache("History"),
+  );
+  chrome.history.onVisitRemoved.addListener(() =>
+    broadcastInvalidateCache("History"),
+  );
+
   /**
    * @description コマンドのルーティング
    */

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -22,7 +22,7 @@ const broadcastInvalidateCache = (kind: InvalidateCacheKind) => {
   chrome.runtime
     .sendMessage({ type: MessageType.INVALIDATE_CACHE, kind })
     .catch(() => {
-      // ポップアップが開いていない場合は "Receiving end does not exist" になるが正常系
+      // ポップアップ・サイドパネルが開いていない場合は正常系
     });
 };
 

--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -17,6 +17,9 @@ const {
   SWITCH_VIEW_MODE,
 } = MessageType;
 
+// 前回の QUERY_RESULT リクエストをキャンセルするためのコントローラー
+let queryResultController: AbortController | null = null;
+
 function sendResponse(
   type: string,
   result: unknown,
@@ -107,13 +110,20 @@ export function routeMessage(
     }
 
     case QUERY_RESULT: {
+      // 前のリクエストをキャンセルして新しいコントローラーを作成
+      queryResultController?.abort();
+      queryResultController = new AbortController();
+      const { signal } = queryResultController;
+
       const { filters } = message;
       resultService
-        .query({ filters })
+        .query({ filters, signal })
         .then((results) => {
+          if (signal.aborted) return;
           sendResponse(QUERY_RESULT, results, response);
         })
         .catch((error) => {
+          if (signal.aborted) return;
           console.error("Error handling QUERY_RESULT:", error);
           sendResponse(QUERY_RESULT, [], response);
         });

--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -17,8 +17,9 @@ const {
   SWITCH_VIEW_MODE,
 } = MessageType;
 
-// 前回の QUERY_RESULT リクエストをキャンセルするためのコントローラー
-let queryResultController: AbortController | null = null;
+// 送信元コンテキスト（popup / sidepanel）ごとに AbortController を管理する。
+// これにより、複数コンテキストが同時に開いていても互いにキャンセルしない。
+const queryResultControllers = new Map<string, AbortController>();
 
 function sendResponse(
   type: string,
@@ -71,13 +72,13 @@ function isRouterMessage(msg: unknown): msg is RouterMessage {
  * 受信したメッセージを解析し、適切なサービスへルーティングします。
  *
  * @param message 受信したメッセージオブジェクト
- * @param _sender メッセージの送信元情報
+ * @param sender メッセージの送信元情報
  * @param response レスポンスを返却するためのコールバック関数
  * @returns メッセージが正常に処理された場合は true、それ以外は false
  */
 export function routeMessage(
   message: unknown,
-  _sender: chrome.runtime.MessageSender,
+  sender: chrome.runtime.MessageSender,
   response: (res?: object) => void,
 ): boolean {
   if (!isRouterMessage(message)) return false;
@@ -110,10 +111,12 @@ export function routeMessage(
     }
 
     case QUERY_RESULT: {
-      // 前のリクエストをキャンセルして新しいコントローラーを作成
-      queryResultController?.abort();
-      queryResultController = new AbortController();
-      const { signal } = queryResultController;
+      // 送信元ごとに前回のリクエストをキャンセルして新しいコントローラーを作成
+      const senderKey = sender.documentId ?? sender.url ?? "unknown";
+      queryResultControllers.get(senderKey)?.abort();
+      const controller = new AbortController();
+      queryResultControllers.set(senderKey, controller);
+      const { signal } = controller;
 
       const { filters } = message;
       resultService

--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -119,12 +119,12 @@ export function routeMessage(
       resultService
         .query({ filters, signal })
         .then((results) => {
-          if (signal.aborted) return;
           sendResponse(QUERY_RESULT, results, response);
         })
         .catch((error) => {
-          if (signal.aborted) return;
-          console.error("Error handling QUERY_RESULT:", error);
+          if (!signal.aborted) {
+            console.error("Error handling QUERY_RESULT:", error);
+          }
           sendResponse(QUERY_RESULT, [], response);
         });
       return true;

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -6,6 +6,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Kind, Result } from "@/services/result";
 import { runtimeService } from "@/services/runtime";
 import {
+  type InvalidateCacheKind,
+  MessageType,
+} from "@/services/runtime/types";
+import {
   DEFAULT_MAX_COUNT,
   DEFAULT_OPTIONS,
   ERROR_CODES,
@@ -209,6 +213,28 @@ export default function useSearchResults(
   useEffect(() => {
     executeSearch();
   }, [executeSearch]);
+
+  // バックグラウンドからの INVALIDATE_CACHE メッセージを受信してキャッシュをクリア
+  useEffect(() => {
+    const handleMessage = (message: unknown) => {
+      if (
+        typeof message !== "object" ||
+        message === null ||
+        !("type" in message) ||
+        (message as { type: unknown }).type !== MessageType.INVALIDATE_CACHE
+      ) {
+        return;
+      }
+      const kind = (message as { kind?: InvalidateCacheKind }).kind;
+      if (!kind || !params.categories.includes(kind as Kind)) return;
+
+      cacheRef.current.clear();
+      executeSearch();
+    };
+
+    chrome.runtime.onMessage.addListener(handleMessage);
+    return () => chrome.runtime.onMessage.removeListener(handleMessage);
+  }, [params.categories, executeSearch]);
 
   return {
     results,

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -228,13 +228,13 @@ export default function useSearchResults(
       const kind = (message as { kind?: InvalidateCacheKind }).kind;
       if (!kind || !params.categories.includes(kind as Kind)) return;
 
-      cacheRef.current.clear();
+      clearCache();
       executeSearch();
     };
 
     chrome.runtime.onMessage.addListener(handleMessage);
     return () => chrome.runtime.onMessage.removeListener(handleMessage);
-  }, [params.categories, executeSearch]);
+  }, [params.categories, executeSearch, clearCache]);
 
   return {
     results,

--- a/src/services/result/service.ts
+++ b/src/services/result/service.ts
@@ -17,7 +17,7 @@ export interface ResultService {
 const queryResults = async (
   request: Type.QueryResultsRequest,
 ): Promise<Type.Result<Type.Kind>[]> => {
-  const { filters } = request;
+  const { filters, signal } = request;
 
   const headResults: Type.Result<Type.Kind>[] = [];
   const queryPromises = [];
@@ -73,6 +73,7 @@ const queryResults = async (
           query: filters?.query ?? "",
           searchEngines: engines,
           option: { count },
+          signal,
         })
         .then((result) => ({ service: "Suggestion", data: result }) as const),
     );

--- a/src/services/result/service.ts
+++ b/src/services/result/service.ts
@@ -10,12 +10,12 @@ import type * as Type from "./types";
 // 型定義
 export interface ResultService {
   query: (
-    request: Type.QueryResultsRequest,
+    request: Type.QueryResultsInternalRequest,
   ) => Promise<Type.Result<Type.Kind>[]>;
 }
 
 const queryResults = async (
-  request: Type.QueryResultsRequest,
+  request: Type.QueryResultsInternalRequest,
 ): Promise<Type.Result<Type.Kind>[]> => {
   const { filters, signal } = request;
 

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -61,6 +61,8 @@ export function isActionResult(
 
 export interface QueryResultsRequest {
   filters: ResultFilters;
+  /** バックグラウンド内部でのみ使用。メッセージ境界を越えない。 */
+  signal?: AbortSignal;
 }
 
 export interface ResultFilters {

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -59,9 +59,13 @@ export function isActionResult(
   return result.type === "Action.Calculation";
 }
 
+/** UI → background メッセージとして使用する公開型（構造化クローン可能） */
 export interface QueryResultsRequest {
   filters: ResultFilters;
-  /** バックグラウンド内部でのみ使用。メッセージ境界を越えない。 */
+}
+
+/** バックグラウンドサービスワーカー内部でのみ使用する型。メッセージ境界を越えない。 */
+export interface QueryResultsInternalRequest extends QueryResultsRequest {
   signal?: AbortSignal;
 }
 

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -23,7 +23,10 @@ export enum MessageType {
   REMOVE_TAB = "REMOVE_TAB",
   QUERY_RESULT = "QUERY_RESULT",
   SWITCH_VIEW_MODE = "SWITCH_VIEW_MODE",
+  INVALIDATE_CACHE = "INVALIDATE_CACHE",
 }
+
+export type InvalidateCacheKind = "Tab" | "Bookmark" | "History";
 
 export interface SwitchViewModeRequest {
   type: MessageType.SWITCH_VIEW_MODE;

--- a/src/services/suggestion/service.ts
+++ b/src/services/suggestion/service.ts
@@ -53,7 +53,10 @@ const fetchApiSuggestions = async (
     // ["query", ["s1", "s2", ...]] の plain JSON 形式
     return extractSuggestions(data);
   } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
+    if (
+      error instanceof Error &&
+      (error.name === "AbortError" || error.name === "TimeoutError")
+    ) {
       return [];
     }
     console.error("Error fetching suggestions:", { query, engine, endpoint, error });

--- a/src/services/suggestion/service.ts
+++ b/src/services/suggestion/service.ts
@@ -59,7 +59,12 @@ const fetchApiSuggestions = async (
     ) {
       return [];
     }
-    console.error("Error fetching suggestions:", { query, engine, endpoint, error });
+    console.error("Error fetching suggestions:", {
+      query,
+      engine,
+      endpoint,
+      error,
+    });
     return [];
   }
 };

--- a/src/services/suggestion/service.ts
+++ b/src/services/suggestion/service.ts
@@ -29,14 +29,17 @@ export interface SuggestionService {
 const fetchApiSuggestions = async (
   query: string,
   engine: SearchEngineValue,
+  signal?: AbortSignal,
 ): Promise<string[]> => {
   const endpoint = buildSuggestUrl(query, engine);
   if (!endpoint) return [];
 
   try {
-    const response = await fetch(endpoint, {
-      signal: AbortSignal.timeout(3000),
-    });
+    const fetchSignal = signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(3000)])
+      : AbortSignal.timeout(3000);
+
+    const response = await fetch(endpoint, { signal: fetchSignal });
 
     if (!response.ok) return [];
 
@@ -50,8 +53,10 @@ const fetchApiSuggestions = async (
     // ["query", ["s1", "s2", ...]] の plain JSON 形式
     return extractSuggestions(data);
   } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return [];
+    }
     console.error("Error fetching suggestions:", { query, engine, endpoint, error });
-
     return [];
   }
 };
@@ -82,10 +87,11 @@ const querySuggestions = async ({
   query,
   option,
   searchEngine = "google",
+  signal,
 }: Type.QuerySuggestionsRequest): Promise<Type.Suggestion[]> => {
   if (!query?.trim()) return [];
 
-  const texts = await fetchApiSuggestions(query, searchEngine);
+  const texts = await fetchApiSuggestions(query, searchEngine, signal);
 
   const result = [
     buildDirectSearch(query, searchEngine),
@@ -103,6 +109,7 @@ const multiEngineQuerySuggestions = async ({
   query,
   option,
   searchEngines,
+  signal,
 }: Type.MultiEngineQuerySuggestionsRequest): Promise<Type.Suggestion[]> => {
   if (!query?.trim()) return [];
 
@@ -111,7 +118,7 @@ const multiEngineQuerySuggestions = async ({
   );
 
   const apiResultsPerEngine = await Promise.all(
-    searchEngines.map((e) => fetchApiSuggestions(query, e)),
+    searchEngines.map((e) => fetchApiSuggestions(query, e, signal)),
   );
 
   const seenTitles = new Set<string>([query]); // 直接検索と同タイトルは除外

--- a/src/services/suggestion/types.ts
+++ b/src/services/suggestion/types.ts
@@ -31,12 +31,14 @@ export interface QuerySuggestionsRequest {
   query: string;
   option?: QueryOption;
   searchEngine?: SearchEngineValue;
+  signal?: AbortSignal;
 }
 
 export interface MultiEngineQuerySuggestionsRequest {
   query: string;
   option?: QueryOption;
   searchEngines: SearchEngineValue[];
+  signal?: AbortSignal;
 }
 
 export interface QueryOption {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "https://ac.ecosia.org/*",
       "https://search.yahoo.co.jp/sugg/*",
     ],
+    minimum_chrome_version: "116",
     commands: {
       OPEN_POPUP: {
         suggested_key: {


### PR DESCRIPTION
## Summary

- **#131** 新しいクエリが来たら前回の suggestion API リクエストをキャンセルする
- **#122** タブ・ブックマークの変更時にキャッシュを無効化して即座に結果を更新する

## Changes

### AbortController (#131)
- `suggestion/types.ts`: `QuerySuggestionsRequest` / `MultiEngineQuerySuggestionsRequest` に `signal?: AbortSignal` を追加
- `suggestion/service.ts`: `AbortSignal.any([signal, AbortSignal.timeout(3000)])` で外部 abort とタイムアウトを両立、`AbortError` を正常系として扱う
- `result/types.ts`: `QueryResultsRequest` に `signal?: AbortSignal` を追加（バックグラウンド内部専用）
- `result/service.ts`: signal を suggestion service に伝播
- `background/router/message.ts`: モジュールスコープで `AbortController` を保持し、新しい `QUERY_RESULT` 到着時に前回をキャンセル

### Cache invalidation (#122)
- `runtime/types.ts`: `MessageType.INVALIDATE_CACHE` と `InvalidateCacheKind` 型を追加
- `background/index.ts`: `chrome.tabs.onCreated/onRemoved/onUpdated` と `chrome.bookmarks.onCreated/onRemoved/onChanged` を購読し、popup/sidepanel に `INVALIDATE_CACHE` をブロードキャスト
- `useSearchResults/hook.ts`: `chrome.runtime.onMessage` で `INVALIDATE_CACHE` を受信し、該当カテゴリがアクティブなら全キャッシュをクリアして再検索

## Test plan

- [x] 検索中に別のクエリを入力 → 前のサジェスト API リクエストがキャンセルされること（Network タブで確認）
- [x] タブを新規作成・削除 → 検索結果がすぐ更新されること
- [x] ブックマークを追加・削除 → 検索結果がすぐ更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR説明

## 概要

このPRは、提案（サジェスト）APIリクエストのキャンセル機能と、タブ/ブックマークの変更時におけるキャッシュ無効化機能を実装します。#131と#122で報告された課題に対応しています。

## 主な変更内容

### 1. AbortController によるリクエストキャンセル機能 (#131)

複数のエンドポイントに `AbortSignal` パラメータを追加し、既存のサジェストリクエストを新しいクエリ入力時にキャンセルできるようにしました：

- **型定義の更新** (`suggestion/types.ts`, `result/types.ts`)：
  - `QuerySuggestionsRequest` と `MultiEngineQuerySuggestionsRequest` に `signal?: AbortSignal` を追加
  - `QueryResultsRequest` に `signal?: AbortSignal` を追加（背景処理専用）

- **サジェスト服取得処理の改善** (`suggestion/service.ts`)：
  - `fetchApiSuggestions` が `AbortSignal` を受け取り、外部シグナルと3000msタイムアウトを `AbortSignal.any()` で組み合わせ
  - キャンセル時（`AbortError`）は例外ログを出力せず、空配列を返す

- **リクエスト伝播** (`result/service.ts`)：
  - クエリ結果リクエストが受け取った `signal` をサジェスト服リクエストに伝播

- **背景タスク側のキャンセル管理** (`background/router/message.ts`)：
  - モジュール スコープで `AbortController` を保持
  - 新しい `QUERY_RESULT` メッセージ到着時に前のコントローラをアボートし、既存リクエストをキャンセル
  - アボートされたリクエストに対するレスポンスは抑制

### 2. キャッシュ無効化機能 (#122)

タブやブックマーク操作時にキャッシュを即座に無効化し、検索結果を更新します：

- **メッセージ型の拡張** (`runtime/types.ts`)：
  - `MessageType.INVALIDATE_CACHE` を新規追加
  - `InvalidateCacheKind` 型（`"Tab" | "Bookmark" | "History"`）を定義

- **背景タスク側のリスナ設定** (`background/index.ts`)：
  - `chrome.tabs.onCreated/onRemoved/onUpdated` リスナでTab変更を検知し、`"Tab"` キャッシュを無効化
  - `chrome.bookmarks.onCreated/onRemoved/onChanged` リスナでブックマーク変更を検知し、`"Bookmark"` キャッシュを無効化
  - `broadcastInvalidateCache()` ヘルパーでポップアップ/サイドパネルに `INVALIDATE_CACHE` メッセージをブロードキャスト

- **フック側のリスナ実装** (`useSearchResults/hook.ts`)：
  - `chrome.runtime.onMessage` で `INVALIDATE_CACHE` メッセージをリッスン
  - 無効化対象のカテゴリがアクティブな場合、キャッシュをクリアして検索を再実行

## 影響範囲

- サジェスト処理：新規入力時に既存リクエストが自動的にキャンセルされるため、不要なネットワークトラフィックが削減されます
- 検索結果表示：タブやブックマークの変更が即座に検索結果に反映されるようになります

## 実装の詳細

- **後方互換性**：`signal` パラメータはオプションであり、既存のコードは変更なしで動作します
- **エラーハンドリング**：`AbortError` は正常な処理として扱われ、ログ出力されません
- **タイムアウト**：サジェスト取得リクエストには3秒のタイムアウトが自動的に適用されます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->