### PR TITLE
fix: address medium-priority bugs (#159, #160, #162, #163)

### DIFF
--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -85,7 +85,7 @@ export function routeMessage(
 
   switch (message.type) {
     case OPEN_POPUP:
-      contentService.openTabs(contentService.open({}));
+      contentService.openTabs(() => contentService.open({}));
       return true;
 
     case CREATE_TAB: {

--- a/src/features/search/hooks/useSearchResults/constants.ts
+++ b/src/features/search/hooks/useSearchResults/constants.ts
@@ -17,6 +17,9 @@ export const DEFAULT_OPTIONS: Required<UseSearchResultsOptions> = {
 /** デフォルトの最大取得件数 */
 export const DEFAULT_MAX_COUNT = 1000;
 
+/** キャッシュの最大エントリ数（FIFO eviction） */
+export const MAX_CACHE_SIZE = 50;
+
 /** エラーメッセージ */
 export const ERROR_MESSAGES = {
   TIMEOUT: "検索がタイムアウトしました",

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_OPTIONS,
   ERROR_CODES,
   ERROR_MESSAGES,
+  MAX_CACHE_SIZE,
 } from "./constants";
 import {
   generateCacheKey,
@@ -117,13 +118,17 @@ export default function useSearchResults(
         fetchedResults = await withTimeout(fetchFn(), opts.timeoutMs);
       }
 
-      // キャッシュに保存
+      // キャッシュに保存（FIFO eviction でサイズ上限を維持）
       if (opts.enableCache) {
         cacheRef.current.set(cacheKey, {
           data: fetchedResults,
           timestamp: Date.now(),
           key: cacheKey,
         });
+        if (cacheRef.current.size > MAX_CACHE_SIZE) {
+          const oldestKey = cacheRef.current.keys().next().value;
+          if (oldestKey !== undefined) cacheRef.current.delete(oldestKey);
+        }
       }
 
       return fetchedResults;

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -62,6 +62,14 @@ storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
   updateSnapshot(newTheme ?? getDefaultTheme());
 });
 
+window
+  .matchMedia("(prefers-color-scheme: dark)")
+  .addEventListener("change", () => {
+    if (snapshot.theme === "system") {
+      updateSnapshot("system");
+    }
+  });
+
 void hydrateTheme();
 
 export default function useTheme() {

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -62,13 +62,15 @@ storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
   updateSnapshot(newTheme ?? getDefaultTheme());
 });
 
-window
-  .matchMedia("(prefers-color-scheme: dark)")
-  .addEventListener("change", () => {
-    if (snapshot.theme === "system") {
-      updateSnapshot("system");
-    }
-  });
+if (typeof window !== "undefined" && window.matchMedia) {
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      if (snapshot.theme === "system") {
+        updateSnapshot("system");
+      }
+    });
+}
 
 void hydrateTheme();
 

--- a/src/services/content/service.ts
+++ b/src/services/content/service.ts
@@ -28,13 +28,11 @@ const close = (): void => {
   window?.close();
 };
 
-const openTabs = async (action: Promise<Type.OpenResponse>): Promise<void> =>
-  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
-    const tabId = tabs[0].id;
-    if (tabId) {
-      await action;
-    }
-  });
+const openTabs = async (action: Promise<Type.OpenResponse>): Promise<void> => {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tabs[0]?.id) return;
+  await action;
+};
 
 // サービスオブジェクトのエクスポート
 export const contentService: ContentService = {

--- a/src/services/content/service.ts
+++ b/src/services/content/service.ts
@@ -8,7 +8,7 @@ import type * as Type from "./types";
 export interface ContentService {
   open: (request: Type.OpenRequest) => Promise<Type.OpenResponse>;
   close: () => void;
-  openTabs: (action: Promise<Type.OpenResponse>) => Promise<void>;
+  openTabs: (action: () => Promise<Type.OpenResponse>) => Promise<void>;
 }
 
 // サービス実装
@@ -28,10 +28,12 @@ const close = (): void => {
   window?.close();
 };
 
-const openTabs = async (action: Promise<Type.OpenResponse>): Promise<void> => {
+const openTabs = async (
+  action: () => Promise<Type.OpenResponse>,
+): Promise<void> => {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tabs[0]?.id) return;
-  await action;
+  await action();
 };
 
 // サービスオブジェクトのエクスポート

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -19,7 +19,7 @@ export interface RuntimeService {
   removeTab: (request: RemoveTabRequest) => Promise<void>;
   queryResults: (request: QueryResultsRequest) => Promise<Result<Kind>[]>;
   openContent: () => Promise<void>;
-  closeContent: () => Promise<void>;
+  closeContent: () => void;
   /**
    * MV3 Service Worker のアイドル停止を防ぐための永続ポート接続を確立する。
    * 接続が切断された場合（SW 強制終了時）は自動的に再接続する。
@@ -145,15 +145,8 @@ const openContent = async (): Promise<void> => {
   }
 };
 
-const closeContent = async (): Promise<void> => {
-  try {
-    await chrome.runtime.sendMessage({ type: MessageType.CLOSE_POPUP });
-  } catch (error) {
-    console.error(`Failed to close Content:`, error);
-    // WARN: 処理が失敗した場合は Popup のサービスを表示する
-    // Contentが表示できない場合はにPopupを表示する
-    contentService.close();
-  }
+const closeContent = (): void => {
+  contentService.close();
 };
 
 export const createRuntimeService = (): RuntimeService => ({


### PR DESCRIPTION
## Summary

- **#159** `useTheme`: Register `matchMedia('prefers-color-scheme: dark')` listener at module level so OS dark mode switches are reflected immediately when `theme = "system"` — previously the UI never re-rendered on OS change
- **#160** `useSearchResults`: Add `MAX_CACHE_SIZE = 50` with FIFO eviction after each `set()` — prevents unbounded Map growth during long sidepanel sessions despite the "LRU-style" comment
- **#162** `contentService.openTabs`: Rewrite from callback-based `chrome.tabs.query` to promise-based with `tabs[0]?.id` bounds check — fixes broken Promise chaining (outer Promise resolved immediately before action completed) and prevents `TypeError` when tab list is empty
- **#163** `runtimeService.closeContent`: Replace broken `sendMessage(CLOSE_POPUP)` (background never handled it, so popup never closed) with direct `contentService.close()`; update interface type from `Promise<void>` to `void`

## Test plan

- [ ] With `theme = "system"`, toggle OS dark mode — UI should follow immediately
- [ ] Trigger many unique queries in sidepanel; confirm cache size stays ≤ 50
- [ ] Open popup with no active tabs (all windows minimized) — should not throw TypeError
- [ ] Verify `runtimeService.closeContent()` calls `window.close()` directly
- [ ] `pnpm compile` passes with no errors
- [ ] `pnpm check` reports no issues

Closes #159, #160, #162, #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# 中優先度バグ修正 (#159, #160, #162, #163)

## 概要
このPRは4つの中優先度のバグを修正します。

## 変更内容

### #159: useTheme でシステムの色スキーム変更に対応
`src/features/theme/hooks/useTheme.ts` に `window.matchMedia("(prefers-color-scheme: dark)")` の変更リスナーをモジュール スコープで追加しました。OSの色スキーム設定が変更された際、現在の保存されたテーマモードが `"system"` の場合、`updateSnapshot("system")` を呼び出して内部スナップショットをリフレッシュし、`isDarkMode` を再計算します。これにより、theme="system" のユーザーがサイドパネルを開いたままOSのダークモード設定を変更した場合、UIが即座に反応するようになります。

### #160: useSearchResults のキャッシュサイズを制限
- `src/features/search/hooks/useSearchResults/constants.ts` に `MAX_CACHE_SIZE = 50` 定数を追加
- `src/features/search/hooks/useSearchResults/hook.ts` でキャッシュ有効時に、新しいエントリを保存した後、キャッシュサイズが上限を超えた場合にFIFO方式で最も古いエントリを削除するよう実装

これにより、長時間のサイドパネルセッション中でもキャッシュが無制限に成長することを防ぎます。

### #162: contentService.openTabs のPromiseチェーン修正
`src/services/content/service.ts` の `openTabs` をコールバックベースの `chrome.tabs.query(..., async (tabs) => ...)` 実装から `async/await` フローに書き直しました。タブクエリ結果を待機し、アクティブなタブIDがない場合は早期リターン、その後に提供されたアクション Promise を待機するようにしました。これにより、返された `Promise<void>` はアクションが完了した後に resolve され、タブリストが空の場合の TypeError も防ぎます。

### #163: runtimeService.closeContent の簡素化
`src/services/runtime/service.ts` の `RuntimeService.closeContent` を非同期実装から同期実装に変更しました。`chrome.runtime.sendMessage({ type: MessageType.CLOSE_POPUP })` 経由でのポップアップクローズ試行（背景では処理されず、ポップアップも閉じない）から `contentService.close()` への直接呼び出しに置き換え、インターフェース戻り値の型を `Promise<void>` から `void` に変更しました。

## テスト計画
- theme="system" の状態で、OSのダークモード設定を切り替えるとUIが即座に更新される
- 多くのユニークなサイドパネルクエリをトリガーして、キャッシュサイズが50以下に保たれることを確認
- アクティブなタブがない状態でポップアップを開いても TypeError が発生しない
- `runtimeService.closeContent()` が `window.close()` を直接呼び出すことを確認
- `pnpm compile` と `pnpm check` がエラーなく実行される

<!-- end of auto-generated comment: release notes by coderabbit.ai -->