### PR TITLE
[Claude Code] fix: add .catch() to storageService.getViewMode() initialization

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -35,13 +35,7 @@ export default defineBackground(() => {
   };
 
   // サイドパネルの初期化
-  storageService
-    .getViewMode()
-    .then(updateViewMode)
-    .catch((error) => {
-      console.error("Failed to initialize view mode:", error);
-      updateViewMode("popup");
-    });
+  storageService.getViewMode().then(updateViewMode);
 
   // viewMode変更時にキャッシュとサイドパネルの動作を更新
   storageService.subscribe(SyncStorageKey.ViewMode, (viewMode) => {

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -35,6 +35,7 @@ export default defineBackground(() => {
   };
 
   // サイドパネルの初期化
+  // getViewMode() は内部でエラーをキャッチしデフォルト値を返すため .catch() は不要
   storageService.getViewMode().then(updateViewMode);
 
   // viewMode変更時にキャッシュとサイドパネルの動作を更新

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -35,7 +35,13 @@ export default defineBackground(() => {
   };
 
   // サイドパネルの初期化
-  storageService.getViewMode().then(updateViewMode);
+  storageService
+    .getViewMode()
+    .then(updateViewMode)
+    .catch((error) => {
+      console.error("Failed to initialize view mode:", error);
+      updateViewMode("popup");
+    });
 
   // viewMode変更時にキャッシュとサイドパネルの動作を更新
   storageService.subscribe(SyncStorageKey.ViewMode, (viewMode) => {


### PR DESCRIPTION
## Summary

- Closes #178
- `storageService.getViewMode()` で `.catch()` が欠けていたため、Chrome Storage 読み込み失敗時にエラーが無音で握り潰されていた
- エラー時は `console.error` でログを出力し、フォールバック値 `"popup"` で `updateViewMode` を呼ぶよう修正

## Test plan

- [ ] 通常起動: viewMode が Storage の値に従って正しく設定されることを確認
- [ ] Storage エラー時: フォールバック `"popup"` で動作し、コンソールにエラーが出力されることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR概要

ストレージサービスのビューモード初期化における不足していたエラーハンドリングを追加しました。

## 変更内容

`src/entrypoints/background/index.ts`に`storageService.getViewMode()`の呼び出しに対して`.catch()`ハンドラーを追加しました。

**変更の詳細：**
- `storageService.getViewMode()`プロミスに`.catch()`チェーンを追加
- エラーが発生した場合、`console.error("Failed to initialize view mode:", error)`でエラーをログ出力
- フォールバック処理として`updateViewMode("popup")`を実行し、デフォルト状態に設定

**コード例：**
```typescript
storageService
  .getViewMode()
  .then(updateViewMode)
  .catch((error) => {
    console.error("Failed to initialize view mode:", error);
    updateViewMode("popup");
  });
```

## 影響範囲

- **パブリックAPI変更：** なし
- **ロジック変更：** 保存先ストレージの読み込み失敗時の動作を改善
- **その他の処理：** 変更なし

## 解決する問題

#178で報告されていたChrome Storage読み込み失敗時のサイレント失敗の問題を解決しました。従来は、クォータ不足やパーミッションエラーなどによる失敗が無視され、`updateViewMode`が呼ばれないままキャッシュされたビューモードが"popup"のままになっていました。この修正により、エラーが適切にログされ、確実にフォールバック処理が実行されるようになりました。

## 変更統計

- 変更行数：+7/-1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->