### PR TITLE
[Claude Code] fix: store MediaQueryList reference to prevent listener accumulation

### DIFF
--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -16,12 +16,16 @@ export type ThemeState = ThemeSnapshot & {
 
 const listeners = new Set<() => void>();
 
+const darkModeMediaQuery =
+  typeof window !== "undefined" && window.matchMedia
+    ? window.matchMedia("(prefers-color-scheme: dark)")
+    : null;
+
 /**
  * ウィンドウのダークモード設定を取得
  */
 export const isWindowDarkMode = (): boolean => {
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  return mediaQuery.matches;
+  return darkModeMediaQuery?.matches ?? false;
 };
 
 const buildSnapshot = (theme: ThemeValue): ThemeSnapshot => ({
@@ -74,12 +78,14 @@ const handleColorSchemeChange = () => {
   }
 };
 
-const darkModeMediaQuery =
-  typeof window !== "undefined" && window.matchMedia
-    ? window.matchMedia("(prefers-color-scheme: dark)")
-    : null;
-
 darkModeMediaQuery?.addEventListener("change", handleColorSchemeChange);
+
+// HMRでモジュールが再評価される際にリスナーを削除してリークを防ぐ
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    darkModeMediaQuery?.removeEventListener("change", handleColorSchemeChange);
+  });
+}
 
 void hydrateTheme();
 

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -68,15 +68,18 @@ storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
   updateSnapshot(newTheme ?? "system");
 });
 
-if (typeof window !== "undefined" && window.matchMedia) {
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", () => {
-      if (snapshot.theme === "system") {
-        updateSnapshot("system");
-      }
-    });
-}
+const handleColorSchemeChange = () => {
+  if (snapshot.theme === "system") {
+    updateSnapshot("system");
+  }
+};
+
+const darkModeMediaQuery =
+  typeof window !== "undefined" && window.matchMedia
+    ? window.matchMedia("(prefers-color-scheme: dark)")
+    : null;
+
+darkModeMediaQuery?.addEventListener("change", handleColorSchemeChange);
 
 void hydrateTheme();
 


### PR DESCRIPTION
## Summary

- Closes #179
- `window.matchMedia("(prefers-color-scheme: dark)")` を毎回呼ぶと新しい `MediaQueryList` インスタンスが返るため、`removeEventListener` が機能しなかった
- `MediaQueryList` インスタンスとリスナー関数をモジュール変数に保存することで、将来のクリーンアップを可能にした
- HMR や拡張機能リロード時にリスナーが蓄積する問題を修正

## Test plan

- [ ] テーマが `system` のとき、OS ダークモード切り替えでテーマが更新されることを確認
- [ ] テーマが `light`/`dark` のとき、OS 設定変更でテーマが変わらないことを確認
- [ ] 開発環境で HMR 後もリスナーが1つのみ動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)