### PR TITLE
[Claude Code] fix: add isRuntimeResponse type guard to validate sendMessage response

### DIFF
--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -12,7 +12,7 @@ import { KEEPALIVE_INTERVAL_MS } from "./constants";
 import runtimeServiceDependencies from "./container";
 import type { RuntimeService } from "./interface";
 import { logger, RuntimeServiceError, toError } from "./internal";
-import { MessageType, type RuntimeResponse } from "./types";
+import { isRuntimeResponse, MessageType } from "./types";
 
 function connectPort(
   name: string,
@@ -92,12 +92,18 @@ const queryResults = async ({
   filters,
 }: QueryResultsRequest): Promise<Result<Kind>[]> => {
   try {
-    const response = (await chrome.runtime.sendMessage({
+    const raw = await chrome.runtime.sendMessage({
       type: MessageType.QUERY_RESULT,
       filters,
-    })) as RuntimeResponse<Result<Kind>[]>;
+    });
 
-    return response.result;
+    if (!isRuntimeResponse<Result<Kind>[]>(raw)) {
+      throw new RuntimeServiceError(
+        "Unexpected response shape from QUERY_RESULT",
+      );
+    }
+
+    return raw.result;
   } catch (error) {
     if (error instanceof RuntimeServiceError) {
       throw error;

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -92,7 +92,7 @@ const queryResults = async ({
   filters,
 }: QueryResultsRequest): Promise<Result<Kind>[]> => {
   try {
-    const raw = await chrome.runtime.sendMessage({
+    const raw: unknown = await chrome.runtime.sendMessage({
       type: MessageType.QUERY_RESULT,
       filters,
     });

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -8,6 +8,18 @@ export interface RuntimeResponse<T = unknown> {
   result: T;
 }
 
+export function isRuntimeResponse<T>(
+  value: unknown,
+): value is RuntimeResponse<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof (value as { type: unknown }).type === "string" &&
+    "result" in value
+  );
+}
+
 // リクエスト型定義（将来的な拡張用）
 export interface QueryTabsRequest {
   query: string;

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -8,6 +8,13 @@ export interface RuntimeResponse<T = unknown> {
   result: T;
 }
 
+/**
+ * 値が RuntimeResponse 型の構造を持っているかを確認する型ガード関数。
+ * chrome.runtime.sendMessage のレスポンスを安全にナローイングするために使用する。
+ *
+ * @param value 検証する値
+ * @returns `{ type: string, result: T }` の構造を持つ場合は true
+ */
 export function isRuntimeResponse<T>(
   value: unknown,
 ): value is RuntimeResponse<T> {


### PR DESCRIPTION
## Summary

- Closes #180
- `chrome.runtime.sendMessage` のレスポンスを `as RuntimeResponse<T>` で検証なしキャストしていた
- `isRuntimeResponse<T>` 型ガード関数を `types.ts` に追加し、`service.ts` で実行時検証を行うよう修正
- レスポンス形式が不正な場合は `RuntimeServiceError` をスローして明確に失敗する

## Test plan

- [ ] 通常の検索クエリ: 結果が正常に返ることを確認
- [ ] バックグラウンドが予期しないレスポンスを返した場合: エラーが適切にスローされることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)