### PR TITLE
[Claude Code] fix: skip notify() when engines content is unchanged in useSearchEngines

### DIFF
--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -17,12 +17,13 @@ const notify = () => {
 
 const updateSnapshot = (engines: SearchEngineValue[]) => {
   if (
-    snapshot.length === engines.length &&
-    snapshot.every((e, i) => e === engines[i])
+    snapshot === engines ||
+    (snapshot.length === engines.length &&
+      snapshot.every((e, i) => e === engines[i]))
   ) {
     return;
   }
-  snapshot = engines;
+  snapshot = [...engines];
   notify();
 };
 

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -16,6 +16,12 @@ const notify = () => {
 };
 
 const updateSnapshot = (engines: SearchEngineValue[]) => {
+  if (
+    snapshot.length === engines.length &&
+    snapshot.every((e, i) => e === engines[i])
+  ) {
+    return;
+  }
   snapshot = engines;
   notify();
 };


### PR DESCRIPTION
## Summary

- Closes #174
- `updateSnapshot` が毎回 `notify()` を呼び、同じ内容でも `useSyncExternalStore` が再レンダリングを引き起こしていた
- 配列の長さと各要素が一致する場合は早期リターンする比較ガードを追加
- `useTheme` / `useViewMode` の参照安定性パターンと統一

## Test plan

- [ ] 検索エンジン設定を変更: UI に即座に反映されることを確認
- [ ] ストレージが同じ値でコールバックされた場合: 不要な再レンダリングが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)