### PR TITLE
[Claude Code] fix: add isInvalidateCacheMessage type guard for INVALIDATE_CACHE handler

### DIFF
--- a/src/features/search/hooks/useSearchResults/helper.ts
+++ b/src/features/search/hooks/useSearchResults/helper.ts
@@ -4,7 +4,28 @@
 
 import type { Kind } from "@/services/result";
 import type { SearchEngineValue } from "@/services/storage/types";
+import {
+  type InvalidateCacheKind,
+  MessageType,
+} from "@/services/runtime/types";
 import type { CacheEntry } from "./types";
+
+/**
+ * メッセージが INVALIDATE_CACHE メッセージかどうかを確認する型ガード関数。
+ * chrome.runtime.onMessage のコールバック引数を安全にナローイングするために使用する。
+ */
+export function isInvalidateCacheMessage(
+  message: unknown,
+): message is { type: MessageType.INVALIDATE_CACHE; kind: InvalidateCacheKind } {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    (message as { type: unknown }).type === MessageType.INVALIDATE_CACHE &&
+    "kind" in message &&
+    typeof (message as { kind: unknown }).kind === "string"
+  );
+}
 
 /**
  * キャッシュキーを生成

--- a/src/features/search/hooks/useSearchResults/helper.ts
+++ b/src/features/search/hooks/useSearchResults/helper.ts
@@ -3,11 +3,11 @@
  */
 
 import type { Kind } from "@/services/result";
-import type { SearchEngineValue } from "@/services/storage/types";
 import {
   type InvalidateCacheKind,
   MessageType,
 } from "@/services/runtime/types";
+import type { SearchEngineValue } from "@/services/storage/types";
 import type { CacheEntry } from "./types";
 
 /**
@@ -16,7 +16,10 @@ import type { CacheEntry } from "./types";
  */
 export function isInvalidateCacheMessage(
   message: unknown,
-): message is { type: MessageType.INVALIDATE_CACHE; kind: InvalidateCacheKind } {
+): message is {
+  type: MessageType.INVALIDATE_CACHE;
+  kind: InvalidateCacheKind;
+} {
   return (
     typeof message === "object" &&
     message !== null &&

--- a/src/features/search/hooks/useSearchResults/helper.ts
+++ b/src/features/search/hooks/useSearchResults/helper.ts
@@ -13,20 +13,18 @@ import type { CacheEntry } from "./types";
 /**
  * メッセージが INVALIDATE_CACHE メッセージかどうかを確認する型ガード関数。
  * chrome.runtime.onMessage のコールバック引数を安全にナローイングするために使用する。
+ * @param message - 検証するメッセージ
+ * @returns INVALIDATE_CACHE メッセージの場合は true
  */
-export function isInvalidateCacheMessage(
-  message: unknown,
-): message is {
+export function isInvalidateCacheMessage(message: unknown): message is {
   type: MessageType.INVALIDATE_CACHE;
   kind: InvalidateCacheKind;
 } {
+  if (typeof message !== "object" || message === null) return false;
+  const m = message as { type?: unknown; kind?: unknown };
   return (
-    typeof message === "object" &&
-    message !== null &&
-    "type" in message &&
-    (message as { type: unknown }).type === MessageType.INVALIDATE_CACHE &&
-    "kind" in message &&
-    typeof (message as { kind: unknown }).kind === "string"
+    m.type === MessageType.INVALIDATE_CACHE &&
+    (m.kind === "Tab" || m.kind === "Bookmark" || m.kind === "History")
   );
 }
 

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -220,7 +220,7 @@ export default function useSearchResults(
   useEffect(() => {
     const handleMessage = (message: unknown) => {
       if (!isInvalidateCacheMessage(message)) return;
-      if (!params.categories.includes(message.kind as Kind)) return;
+      if (!params.categories.includes(message.kind)) return;
 
       clearCache();
       executeSearch();

--- a/src/features/search/hooks/useSearchResults/hook.ts
+++ b/src/features/search/hooks/useSearchResults/hook.ts
@@ -6,10 +6,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Kind, Result } from "@/services/result";
 import { runtimeService } from "@/services/runtime";
 import {
-  type InvalidateCacheKind,
-  MessageType,
-} from "@/services/runtime/types";
-import {
   DEFAULT_MAX_COUNT,
   DEFAULT_OPTIONS,
   ERROR_CODES,
@@ -19,6 +15,7 @@ import {
 import {
   generateCacheKey,
   isCacheValid,
+  isInvalidateCacheMessage,
   withRetry,
   withTimeout,
 } from "./helper";
@@ -222,16 +219,8 @@ export default function useSearchResults(
   // バックグラウンドからの INVALIDATE_CACHE メッセージを受信してキャッシュをクリア
   useEffect(() => {
     const handleMessage = (message: unknown) => {
-      if (
-        typeof message !== "object" ||
-        message === null ||
-        !("type" in message) ||
-        (message as { type: unknown }).type !== MessageType.INVALIDATE_CACHE
-      ) {
-        return;
-      }
-      const kind = (message as { kind?: InvalidateCacheKind }).kind;
-      if (!kind || !params.categories.includes(kind as Kind)) return;
+      if (!isInvalidateCacheMessage(message)) return;
+      if (!params.categories.includes(message.kind as Kind)) return;
 
       clearCache();
       executeSearch();


### PR DESCRIPTION
## Summary

- Closes #181
- Added `isInvalidateCacheMessage` type guard to `helper.ts` that validates both `type` and `kind` fields
- Replaced the inline double-cast pattern in `hook.ts` with the new guard, eliminating `as` casts at the Chrome message boundary

## Test plan

- [ ] TypeScript compiles without errors (`pnpm compile`)
- [ ] Verify INVALIDATE_CACHE messages still trigger cache clear and re-fetch in the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)