### PR TITLE
[Claude Code] refactor: add reference-stability guard to useTheme updateSnapshot

### DIFF
--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -48,6 +48,7 @@ const notify = () => {
 
 const updateSnapshot = (theme: ThemeValue) => {
   const next = buildSnapshot(theme);
+  // 値が変わっていない場合は通知をスキップし、不要な再レンダリングを防ぐ
   if (snapshot.theme === next.theme && snapshot.isDarkMode === next.isDarkMode)
     return;
   snapshot = next;

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -47,7 +47,9 @@ const notify = () => {
 };
 
 const updateSnapshot = (theme: ThemeValue) => {
-  snapshot = buildSnapshot(theme);
+  const next = buildSnapshot(theme);
+  if (snapshot.theme === next.theme && snapshot.isDarkMode === next.isDarkMode) return;
+  snapshot = next;
   notify();
 };
 

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -48,7 +48,8 @@ const notify = () => {
 
 const updateSnapshot = (theme: ThemeValue) => {
   const next = buildSnapshot(theme);
-  if (snapshot.theme === next.theme && snapshot.isDarkMode === next.isDarkMode) return;
+  if (snapshot.theme === next.theme && snapshot.isDarkMode === next.isDarkMode)
+    return;
   snapshot = next;
   notify();
 };


### PR DESCRIPTION
## Summary

- Closes #161
- Added a value comparison guard in `updateSnapshot` to skip `notify()` when both `theme` and `isDarkMode` are unchanged
- Prevents unnecessary re-renders from `useSyncExternalStore` subscribers when the snapshot content hasn't actually changed

## Test plan

- [ ] TypeScript compiles without errors (`pnpm compile`)
- [ ] Theme switching still works correctly in the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)