### PR TITLE
[Claude Code] refactor: add JSDoc to module-level state in useSyncExternalStore hooks

### DIFF
--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -5,6 +5,11 @@ import {
   storageService,
 } from "@/services/storage";
 
+/**
+ * useSyncExternalStore パターン用のモジュールレベル状態。
+ * コンポーネントの再マウントをまたいでサブスクリプション状態を保持するために
+ * 意図的にモジュールスコープに置く。
+ */
 const listeners = new Set<() => void>();
 
 let snapshot: SearchEngineValue[] = [];

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -5,6 +5,11 @@ import {
   type ViewModeValue,
 } from "@/services/storage";
 
+/**
+ * useSyncExternalStore パターン用のモジュールレベル状態。
+ * コンポーネントの再マウントをまたいでサブスクリプション状態を保持するために
+ * 意図的にモジュールスコープに置く。
+ */
 const listeners = new Set<() => void>();
 
 let snapshot: ViewModeValue = "popup";

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -38,6 +38,7 @@ const buildSnapshot = (theme: ThemeValue): ThemeSnapshot => ({
   isDarkMode: theme === "system" ? isWindowDarkMode() : theme === "dark",
 });
 
+/** useSyncExternalStore パターン用のモジュールレベル状態（上記 listeners と同様）。 */
 let snapshot: ThemeSnapshot = buildSnapshot("system");
 
 export const initialState: ThemeState = {

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -14,6 +14,11 @@ export type ThemeState = ThemeSnapshot & {
   setTheme: (value: ThemeValue) => void;
 };
 
+/**
+ * useSyncExternalStore パターン用のモジュールレベル状態。
+ * コンポーネントの再マウントをまたいでサブスクリプション状態を保持するために
+ * 意図的にモジュールスコープに置く。
+ */
 const listeners = new Set<() => void>();
 
 const darkModeMediaQuery =


### PR DESCRIPTION
## Summary

- Closes #182
- Added JSDoc comment block before the module-level `listeners` + `snapshot` declarations in `useViewMode.ts`, `useSearchEngines.ts`, and `useTheme.ts`
- Explains that the module-scope placement is intentional — to persist subscription state across component remounts

## Test plan

- [ ] TypeScript compiles without errors (`pnpm compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)