### PR TITLE
[Claude Code] fix: validate Chrome Storage values in storageService.subscribe callbacks

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -2,7 +2,11 @@ import {
   type InvalidateCacheKind,
   MessageType,
 } from "@/services/runtime/types";
-import { storageService } from "@/services/storage";
+import {
+  getDefaultViewMode,
+  isValidViewMode,
+  storageService,
+} from "@/services/storage";
 import { SyncStorageKey, type ViewModeValue } from "@/services/storage/types";
 import { routeCommand, routeMessage } from "./router";
 
@@ -40,7 +44,7 @@ export default defineBackground(() => {
 
   // viewMode変更時にキャッシュとサイドパネルの動作を更新
   storageService.subscribe(SyncStorageKey.ViewMode, (viewMode) => {
-    updateViewMode(viewMode ?? "popup");
+    updateViewMode(isValidViewMode(viewMode) ? viewMode : getDefaultViewMode());
   });
 
   // ポート接続の処理:

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -1,5 +1,7 @@
 import { useCallback, useSyncExternalStore } from "react";
 import {
+  getDefaultSearchEngines,
+  isValidSearchEngines,
   type SearchEngineValue,
   SyncStorageKey,
   storageService,
@@ -45,9 +47,7 @@ const hydrateSearchEngines = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.SearchEngines, (newEngines) => {
-  if (newEngines) {
-    updateSnapshot(newEngines);
-  }
+  updateSnapshot(isValidSearchEngines(newEngines) ? newEngines : getDefaultSearchEngines());
 });
 
 void hydrateSearchEngines();

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -47,7 +47,9 @@ const hydrateSearchEngines = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.SearchEngines, (newEngines) => {
-  updateSnapshot(isValidSearchEngines(newEngines) ? newEngines : getDefaultSearchEngines());
+  updateSnapshot(
+    isValidSearchEngines(newEngines) ? newEngines : getDefaultSearchEngines(),
+  );
 });
 
 void hydrateSearchEngines();

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -42,7 +42,7 @@ const hydrateSearchEngines = async () => {
     updateSnapshot(stored);
   } catch (error) {
     console.error("Failed to hydrate searchEngines", error);
-    updateSnapshot(["google"]);
+    updateSnapshot(getDefaultSearchEngines());
   }
 };
 

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -40,7 +40,9 @@ const hydrateViewMode = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
-  updateSnapshot(isValidViewMode(newViewMode) ? newViewMode : getDefaultViewMode());
+  updateSnapshot(
+    isValidViewMode(newViewMode) ? newViewMode : getDefaultViewMode(),
+  );
 });
 
 void hydrateViewMode();

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -1,5 +1,7 @@
 import { useCallback, useSyncExternalStore } from "react";
 import {
+  getDefaultViewMode,
+  isValidViewMode,
   SyncStorageKey,
   storageService,
   type ViewModeValue,
@@ -38,7 +40,7 @@ const hydrateViewMode = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
-  updateSnapshot(newViewMode ?? "popup");
+  updateSnapshot(isValidViewMode(newViewMode) ? newViewMode : getDefaultViewMode());
 });
 
 void hydrateViewMode();

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -32,10 +32,10 @@ const getSnapshot = () => snapshot;
 const hydrateViewMode = async () => {
   try {
     const stored = await storageService.getViewMode();
-    updateSnapshot(stored ?? "popup");
+    updateSnapshot(stored ?? getDefaultViewMode());
   } catch (error) {
     console.error("Failed to hydrate viewMode", error);
-    updateSnapshot("popup");
+    updateSnapshot(getDefaultViewMode());
   }
 };
 

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 import {
+  getDefaultTheme,
+  isValidTheme,
   SyncStorageKey,
   storageService,
   type ThemeValue,
@@ -69,7 +71,7 @@ const hydrateTheme = async () => {
 };
 
 storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
-  updateSnapshot(newTheme ?? "system");
+  updateSnapshot(isValidTheme(newTheme) ? newTheme : getDefaultTheme());
 });
 
 const handleColorSchemeChange = () => {

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,2 +1,10 @@
 export * from "./service";
 export * from "./types";
+export {
+  getDefaultSearchEngines,
+  getDefaultTheme,
+  getDefaultViewMode,
+  isValidSearchEngines,
+  isValidTheme,
+  isValidViewMode,
+} from "./helper";

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,5 +1,3 @@
-export * from "./service";
-export * from "./types";
 export {
   getDefaultSearchEngines,
   getDefaultTheme,
@@ -8,3 +6,5 @@ export {
   isValidTheme,
   isValidViewMode,
 } from "./helper";
+export * from "./service";
+export * from "./types";

--- a/src/services/storage/service.ts
+++ b/src/services/storage/service.ts
@@ -10,6 +10,7 @@ import {
   getDefaultTheme,
   getDefaultViewMode,
   isValidSearchEngines,
+  isValidTheme,
   isValidViewMode,
 } from "./helper";
 import type { StorageService } from "./interface";
@@ -67,7 +68,7 @@ const setStorage = async <K extends Type.SyncStorageKey>({
 const getTheme = async (): Promise<Type.ThemeValue> => {
   try {
     const theme = await chromeStorageGet(SyncStorageKey.Theme);
-    return theme || getDefaultTheme();
+    return isValidTheme(theme) ? theme : getDefaultTheme();
   } catch (error) {
     logger.warn("getTheme failed", { error });
     return getDefaultTheme();


### PR DESCRIPTION
## Summary

- Closes #164
- Exported `isValidTheme`, `isValidViewMode`, `isValidSearchEngines` and their defaults from `@/services/storage`
- Updated `useTheme`, `useViewMode`, and `useSearchEngines` subscribe callbacks to validate values with the existing validators before updating state, falling back to defaults on invalid input

## Test plan

- [ ] TypeScript compiles without errors (`pnpm compile`)
- [ ] Theme, view mode, and search engine settings still persist and restore correctly in the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)