### PR TITLE
[Claude Code] refactor: convert ResultList to React.forwardRef pattern

### DIFF
--- a/src/features/search/components/ResultList/ResultList.tsx
+++ b/src/features/search/components/ResultList/ResultList.tsx
@@ -1,48 +1,45 @@
+import React from "react";
 import type { Kind, Result } from "@/services/result";
 import NotFoundItem from "../NotFoundItem/NotFoundItem";
 import ItemComponent from "./part/ResultItem/ResultItem";
 
 export interface ResultListProps {
   items: Result<Kind>[];
-  ref: React.Ref<HTMLUListElement>;
   selectedIndex?: number;
   onClick?: (item: Result<Kind>) => void;
   className?: string;
   listClassName?: string;
 }
 
-const ResultList: React.FC<ResultListProps> = ({
-  items,
-  onClick,
-  ref,
-  selectedIndex,
-  className,
-  listClassName = "max-h-56",
-}) => {
-  const hasItems = items.length > 0;
+const ResultList = React.forwardRef<HTMLUListElement, ResultListProps>(
+  ({ items, onClick, selectedIndex, className, listClassName = "max-h-56" }, ref) => {
+    const hasItems = items.length > 0;
 
-  return (
-    <div className={`pt-3 pb-2 dark:bg-gray-800 ${className ?? ""}`}>
-      <ul
-        className={`pr-3 space-y-1 overflow-x-hidden overflow-y-auto snap-y snap-mandatory ${listClassName}`}
-        ref={ref}
-      >
-        {hasItems ? (
-          items.map((item, index) => (
-            <ItemComponent
-              key={item.id}
-              item={item}
-              index={index}
-              onClick={() => onClick?.(item)}
-              selected={index === selectedIndex}
-            />
-          ))
-        ) : (
-          <NotFoundItem selected={false} />
-        )}
-      </ul>
-    </div>
-  );
-};
+    return (
+      <div className={`pt-3 pb-2 dark:bg-gray-800 ${className ?? ""}`}>
+        <ul
+          className={`pr-3 space-y-1 overflow-x-hidden overflow-y-auto snap-y snap-mandatory ${listClassName}`}
+          ref={ref}
+        >
+          {hasItems ? (
+            items.map((item, index) => (
+              <ItemComponent
+                key={item.id}
+                item={item}
+                index={index}
+                onClick={() => onClick?.(item)}
+                selected={index === selectedIndex}
+              />
+            ))
+          ) : (
+            <NotFoundItem selected={false} />
+          )}
+        </ul>
+      </div>
+    );
+  },
+);
+
+ResultList.displayName = "ResultList";
 
 export default ResultList;

--- a/src/features/search/components/ResultList/ResultList.tsx
+++ b/src/features/search/components/ResultList/ResultList.tsx
@@ -3,6 +3,7 @@ import type { Kind, Result } from "@/services/result";
 import NotFoundItem from "../NotFoundItem/NotFoundItem";
 import ItemComponent from "./part/ResultItem/ResultItem";
 
+/** Props for the ResultList component. */
 export interface ResultListProps {
   items: Result<Kind>[];
   selectedIndex?: number;
@@ -11,8 +12,12 @@ export interface ResultListProps {
   listClassName?: string;
 }
 
+/** 検索結果のリストを描画するコンポーネント。`forwardRef` で `ul` 要素を公開する。 */
 const ResultList = React.forwardRef<HTMLUListElement, ResultListProps>(
-  ({ items, onClick, selectedIndex, className, listClassName = "max-h-56" }, ref) => {
+  (
+    { items, onClick, selectedIndex, className, listClassName = "max-h-56" },
+    ref,
+  ) => {
     const hasItems = items.length > 0;
 
     return (


### PR DESCRIPTION
## Summary

- Closes #176
- Converted `ResultList` from `React.FC` with `ref` as a regular prop to `React.forwardRef<HTMLUListElement, ResultListProps>`
- Removed `ref` from `ResultListProps` interface (it's now the forwarded ref argument)
- Added `ResultList.displayName = "ResultList"` for React DevTools

## Test plan

- [ ] TypeScript compiles without errors (`pnpm compile`)
- [ ] Keyboard navigation and scroll-into-view still work in the extension (ref is used for scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)