### PR TITLE
[Claude Code] refactor: route storage service calls through runtime

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -19,15 +19,17 @@ let cachedViewMode: ViewModeValue = "popup";
 let sidePanelPort: chrome.runtime.Port | null = null;
 
 /**
- * ポップアップ・サイドパネルへキャッシュ無効化メッセージを送信する。
+ * ポップアップ・サイドパネルへメッセージをブロードキャストする。
  * 拡張機能ページが開いていない場合は無視する。
  */
+const broadcast = (message: object) => {
+  chrome.runtime.sendMessage(message).catch(() => {
+    // ポップアップ・サイドパネルが開いていない場合は正常系
+  });
+};
+
 const broadcastInvalidateCache = (kind: InvalidateCacheKind) => {
-  chrome.runtime
-    .sendMessage({ type: MessageType.INVALIDATE_CACHE, kind })
-    .catch(() => {
-      // ポップアップ・サイドパネルが開いていない場合は正常系
-    });
+  broadcast({ type: MessageType.INVALIDATE_CACHE, kind });
 };
 
 export default defineBackground(() => {
@@ -65,6 +67,14 @@ export default defineBackground(() => {
   chrome.tabs.onRemoved.addListener(() => broadcastInvalidateCache("Tab"));
   chrome.tabs.onUpdated.addListener((_id, info) => {
     if (info.status === "complete") broadcastInvalidateCache("Tab");
+  });
+
+  // ストレージ変更を UI へ通知する（UI 側は STORAGE_CHANGED を受信して state を更新する）
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== "sync") return;
+    for (const [key, { newValue }] of Object.entries(changes)) {
+      broadcast({ type: MessageType.STORAGE_CHANGED, key, value: newValue });
+    }
   });
 
   // ブックマークの変更をキャッシュ無効化に反映する

--- a/src/entrypoints/background/router/message.ts
+++ b/src/entrypoints/background/router/message.ts
@@ -1,6 +1,7 @@
 import { contentService } from "@/services/content";
 import { type QueryResultsRequest, resultService } from "@/services/result";
 import { MessageType } from "@/services/runtime/types";
+import { storageService } from "@/services/storage";
 import {
   type CreateTabRequest,
   type RemoveTabRequest,
@@ -13,6 +14,12 @@ const {
   CREATE_TAB,
   UPDATE_TAB,
   REMOVE_TAB,
+  GET_THEME,
+  SET_THEME,
+  GET_VIEW_MODE,
+  SET_VIEW_MODE,
+  GET_SEARCH_ENGINES,
+  SET_SEARCH_ENGINES,
   QUERY_RESULT,
   SWITCH_VIEW_MODE,
 } = MessageType;
@@ -35,7 +42,13 @@ type RouterMessage =
   | ({ type: MessageType.CREATE_TAB } & CreateTabRequest)
   | ({ type: MessageType.UPDATE_TAB } & UpdateTabRequest)
   | ({ type: MessageType.REMOVE_TAB } & RemoveTabRequest)
-  | ({ type: MessageType.QUERY_RESULT } & QueryResultsRequest);
+  | ({ type: MessageType.QUERY_RESULT } & QueryResultsRequest)
+  | { type: MessageType.GET_THEME }
+  | { type: MessageType.SET_THEME; theme: string }
+  | { type: MessageType.GET_VIEW_MODE }
+  | { type: MessageType.SET_VIEW_MODE; viewMode: string }
+  | { type: MessageType.GET_SEARCH_ENGINES }
+  | { type: MessageType.SET_SEARCH_ENGINES; engines: string[] };
 
 function isRouterMessage(msg: unknown): msg is RouterMessage {
   if (typeof msg !== "object" || msg === null || !("type" in msg)) return false;
@@ -43,7 +56,23 @@ function isRouterMessage(msg: unknown): msg is RouterMessage {
   switch (type) {
     case MessageType.OPEN_POPUP:
     case MessageType.SWITCH_VIEW_MODE:
+    case MessageType.GET_THEME:
+    case MessageType.GET_VIEW_MODE:
+    case MessageType.GET_SEARCH_ENGINES:
       return true;
+    case MessageType.SET_THEME:
+      return (
+        "theme" in msg && typeof (msg as { theme: unknown }).theme === "string"
+      );
+    case MessageType.SET_VIEW_MODE:
+      return (
+        "viewMode" in msg &&
+        typeof (msg as { viewMode: unknown }).viewMode === "string"
+      );
+    case MessageType.SET_SEARCH_ENGINES:
+      return (
+        "engines" in msg && Array.isArray((msg as { engines: unknown }).engines)
+      );
     case MessageType.CREATE_TAB:
       return "url" in msg && typeof (msg as { url: unknown }).url === "string";
     case MessageType.UPDATE_TAB:
@@ -157,6 +186,81 @@ export function routeMessage(
       // ユーザージェスチャートークンが有効なうちに同期的に呼ぶ
       chrome.action.openPopup().catch(console.error);
       sendResponse(SWITCH_VIEW_MODE, true, response);
+      return true;
+    }
+
+    case GET_THEME: {
+      storageService
+        .getTheme()
+        .then((theme) => sendResponse(GET_THEME, theme, response))
+        .catch((error) => {
+          console.error("Error handling GET_THEME:", error);
+          sendResponse(GET_THEME, "system", response);
+        });
+      return true;
+    }
+
+    case SET_THEME: {
+      const { theme } = message;
+      storageService
+        .setTheme({
+          theme: theme as import("@/services/storage/types").ThemeValue,
+        })
+        .then(() => sendResponse(SET_THEME, true, response))
+        .catch((error) => {
+          console.error("Error handling SET_THEME:", error);
+          sendResponse(SET_THEME, false, response);
+        });
+      return true;
+    }
+
+    case GET_VIEW_MODE: {
+      storageService
+        .getViewMode()
+        .then((viewMode) => sendResponse(GET_VIEW_MODE, viewMode, response))
+        .catch((error) => {
+          console.error("Error handling GET_VIEW_MODE:", error);
+          sendResponse(GET_VIEW_MODE, "popup", response);
+        });
+      return true;
+    }
+
+    case SET_VIEW_MODE: {
+      const { viewMode } = message;
+      storageService
+        .setViewMode(
+          viewMode as import("@/services/storage/types").ViewModeValue,
+        )
+        .then(() => sendResponse(SET_VIEW_MODE, true, response))
+        .catch((error) => {
+          console.error("Error handling SET_VIEW_MODE:", error);
+          sendResponse(SET_VIEW_MODE, false, response);
+        });
+      return true;
+    }
+
+    case GET_SEARCH_ENGINES: {
+      storageService
+        .getSearchEngines()
+        .then((engines) => sendResponse(GET_SEARCH_ENGINES, engines, response))
+        .catch((error) => {
+          console.error("Error handling GET_SEARCH_ENGINES:", error);
+          sendResponse(GET_SEARCH_ENGINES, ["google"], response);
+        });
+      return true;
+    }
+
+    case SET_SEARCH_ENGINES: {
+      const { engines } = message;
+      storageService
+        .setSearchEngines(
+          engines as import("@/services/storage/types").SearchEngineValue[],
+        )
+        .then(() => sendResponse(SET_SEARCH_ENGINES, true, response))
+        .catch((error) => {
+          console.error("Error handling SET_SEARCH_ENGINES:", error);
+          sendResponse(SET_SEARCH_ENGINES, false, response);
+        });
       return true;
     }
 

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -1,10 +1,11 @@
 import { useCallback, useSyncExternalStore } from "react";
+import { runtimeService } from "@/services/runtime";
+import { isStorageChangedMessage } from "@/services/runtime/types";
 import {
   getDefaultSearchEngines,
   isValidSearchEngines,
   type SearchEngineValue,
   SyncStorageKey,
-  storageService,
 } from "@/services/storage";
 
 /**
@@ -14,6 +15,7 @@ import {
  */
 const listeners = new Set<() => void>();
 
+/** useSyncExternalStore パターン用のモジュールレベル状態（上記 listeners と同様）。 */
 let snapshot: SearchEngineValue[] = [];
 
 const notify = () => {
@@ -43,7 +45,7 @@ const getSnapshot = () => snapshot;
 
 const hydrateSearchEngines = async () => {
   try {
-    const stored = await storageService.getSearchEngines();
+    const stored = await runtimeService.getSearchEngines();
     updateSnapshot(stored);
   } catch (error) {
     console.error("Failed to hydrate searchEngines", error);
@@ -51,10 +53,18 @@ const hydrateSearchEngines = async () => {
   }
 };
 
-storageService.subscribe(SyncStorageKey.SearchEngines, (newEngines) => {
-  updateSnapshot(
-    isValidSearchEngines(newEngines) ? newEngines : getDefaultSearchEngines(),
-  );
+// バックグラウンドからの STORAGE_CHANGED 通知でスナップショットを更新
+chrome.runtime.onMessage.addListener((message: unknown) => {
+  if (
+    isStorageChangedMessage(message) &&
+    message.key === SyncStorageKey.SearchEngines
+  ) {
+    updateSnapshot(
+      isValidSearchEngines(message.value)
+        ? message.value
+        : getDefaultSearchEngines(),
+    );
+  }
 });
 
 void hydrateSearchEngines();
@@ -74,7 +84,7 @@ export default function useSearchEngines() {
     if (engines.length === 0) return;
     const previous = snapshot;
     updateSnapshot(engines);
-    storageService.setSearchEngines(engines).catch((error) => {
+    runtimeService.setSearchEngines(engines).catch((error) => {
       console.error("Failed to persist searchEngines", error);
       updateSnapshot(previous);
     });

--- a/src/features/settings/hooks/useSearchEngines.ts
+++ b/src/features/settings/hooks/useSearchEngines.ts
@@ -54,7 +54,7 @@ const hydrateSearchEngines = async () => {
 };
 
 // バックグラウンドからの STORAGE_CHANGED 通知でスナップショットを更新
-chrome.runtime.onMessage.addListener((message: unknown) => {
+const handleStorageChanged = (message: unknown) => {
   if (
     isStorageChangedMessage(message) &&
     message.key === SyncStorageKey.SearchEngines
@@ -65,7 +65,16 @@ chrome.runtime.onMessage.addListener((message: unknown) => {
         : getDefaultSearchEngines(),
     );
   }
-});
+};
+
+chrome.runtime.onMessage.addListener(handleStorageChanged);
+
+// HMRでモジュールが再評価される際にリスナーを削除してリークを防ぐ
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    chrome.runtime.onMessage.removeListener(handleStorageChanged);
+  });
+}
 
 void hydrateSearchEngines();
 

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -48,7 +48,7 @@ const hydrateViewMode = async () => {
 };
 
 // バックグラウンドからの STORAGE_CHANGED 通知でスナップショットを更新
-chrome.runtime.onMessage.addListener((message: unknown) => {
+const handleStorageChanged = (message: unknown) => {
   if (
     isStorageChangedMessage(message) &&
     message.key === SyncStorageKey.ViewMode
@@ -57,7 +57,16 @@ chrome.runtime.onMessage.addListener((message: unknown) => {
       isValidViewMode(message.value) ? message.value : getDefaultViewMode(),
     );
   }
-});
+};
+
+chrome.runtime.onMessage.addListener(handleStorageChanged);
+
+// HMRでモジュールが再評価される際にリスナーを削除してリークを防ぐ
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    chrome.runtime.onMessage.removeListener(handleStorageChanged);
+  });
+}
 
 void hydrateViewMode();
 

--- a/src/features/settings/hooks/useViewMode.ts
+++ b/src/features/settings/hooks/useViewMode.ts
@@ -1,9 +1,10 @@
 import { useCallback, useSyncExternalStore } from "react";
+import { runtimeService } from "@/services/runtime";
+import { isStorageChangedMessage } from "@/services/runtime/types";
 import {
   getDefaultViewMode,
   isValidViewMode,
   SyncStorageKey,
-  storageService,
   type ViewModeValue,
 } from "@/services/storage";
 
@@ -14,6 +15,7 @@ import {
  */
 const listeners = new Set<() => void>();
 
+/** useSyncExternalStore パターン用のモジュールレベル状態（上記 listeners と同様）。 */
 let snapshot: ViewModeValue = "popup";
 
 const notify = () => {
@@ -23,6 +25,7 @@ const notify = () => {
 };
 
 const updateSnapshot = (viewMode: ViewModeValue) => {
+  if (snapshot === viewMode) return;
   snapshot = viewMode;
   notify();
 };
@@ -36,18 +39,24 @@ const getSnapshot = () => snapshot;
 
 const hydrateViewMode = async () => {
   try {
-    const stored = await storageService.getViewMode();
-    updateSnapshot(stored ?? getDefaultViewMode());
+    const stored = await runtimeService.getViewMode();
+    updateSnapshot(stored);
   } catch (error) {
     console.error("Failed to hydrate viewMode", error);
     updateSnapshot(getDefaultViewMode());
   }
 };
 
-storageService.subscribe(SyncStorageKey.ViewMode, (newViewMode) => {
-  updateSnapshot(
-    isValidViewMode(newViewMode) ? newViewMode : getDefaultViewMode(),
-  );
+// バックグラウンドからの STORAGE_CHANGED 通知でスナップショットを更新
+chrome.runtime.onMessage.addListener((message: unknown) => {
+  if (
+    isStorageChangedMessage(message) &&
+    message.key === SyncStorageKey.ViewMode
+  ) {
+    updateSnapshot(
+      isValidViewMode(message.value) ? message.value : getDefaultViewMode(),
+    );
+  }
 });
 
 void hydrateViewMode();
@@ -57,7 +66,7 @@ export default function useViewMode() {
 
   const setViewMode = useCallback((value: ViewModeValue) => {
     updateSnapshot(value);
-    storageService.setViewMode(value).catch((error) => {
+    runtimeService.setViewMode(value).catch((error) => {
       console.error("Failed to persist viewMode", error);
     });
   }, []);

--- a/src/features/theme/hooks/useTheme.ts
+++ b/src/features/theme/hooks/useTheme.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { runtimeService } from "@/services/runtime";
+import { isStorageChangedMessage } from "@/services/runtime/types";
 import {
   getDefaultTheme,
   isValidTheme,
   SyncStorageKey,
-  storageService,
   type ThemeValue,
 } from "@/services/storage";
 
@@ -72,17 +73,27 @@ const getSnapshot = () => snapshot;
 
 const hydrateTheme = async () => {
   try {
-    const storedTheme = await storageService.getTheme();
-    updateSnapshot(storedTheme ?? "system");
+    const storedTheme = await runtimeService.getTheme();
+    updateSnapshot(storedTheme);
   } catch (error) {
     console.error("Failed to hydrate theme", error);
-    updateSnapshot("system");
+    updateSnapshot(getDefaultTheme());
   }
 };
 
-storageService.subscribe(SyncStorageKey.Theme, (newTheme) => {
-  updateSnapshot(isValidTheme(newTheme) ? newTheme : getDefaultTheme());
-});
+// バックグラウンドからの STORAGE_CHANGED 通知でスナップショットを更新
+const handleStorageChanged = (message: unknown) => {
+  if (
+    isStorageChangedMessage(message) &&
+    message.key === SyncStorageKey.Theme
+  ) {
+    updateSnapshot(
+      isValidTheme(message.value) ? message.value : getDefaultTheme(),
+    );
+  }
+};
+
+chrome.runtime.onMessage.addListener(handleStorageChanged);
 
 const handleColorSchemeChange = () => {
   if (snapshot.theme === "system") {
@@ -96,6 +107,7 @@ darkModeMediaQuery?.addEventListener("change", handleColorSchemeChange);
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     darkModeMediaQuery?.removeEventListener("change", handleColorSchemeChange);
+    chrome.runtime.onMessage.removeListener(handleStorageChanged);
   });
 }
 
@@ -119,7 +131,7 @@ export default function useTheme() {
 
   const setTheme = useCallback((value: ThemeValue) => {
     updateSnapshot(value);
-    storageService.setTheme({ theme: value }).catch((error) => {
+    runtimeService.setTheme(value).catch((error) => {
       console.error("Failed to persist theme", error);
     });
   }, []);

--- a/src/services/runtime/interface.ts
+++ b/src/services/runtime/interface.ts
@@ -4,6 +4,11 @@ import type {
   Result,
 } from "@/services/result/types";
 import type {
+  SearchEngineValue,
+  ThemeValue,
+  ViewModeValue,
+} from "@/services/storage/types";
+import type {
   CreateTabRequest,
   RemoveTabRequest,
   UpdateTabRequest,
@@ -28,4 +33,16 @@ export interface RuntimeService {
    * Automatically reconnects if the connection is dropped.
    */
   connectPort: (name: string, onMessage?: (message: unknown) => void) => void;
+  /** Reads the persisted theme via the background. */
+  getTheme: () => Promise<ThemeValue>;
+  /** Persists the theme via the background. */
+  setTheme: (theme: ThemeValue) => Promise<void>;
+  /** Reads the persisted view mode via the background. */
+  getViewMode: () => Promise<ViewModeValue>;
+  /** Persists the view mode via the background. */
+  setViewMode: (viewMode: ViewModeValue) => Promise<void>;
+  /** Reads the persisted search engines via the background. */
+  getSearchEngines: () => Promise<SearchEngineValue[]>;
+  /** Persists the search engines via the background. */
+  setSearchEngines: (engines: SearchEngineValue[]) => Promise<void>;
 }

--- a/src/services/runtime/service.ts
+++ b/src/services/runtime/service.ts
@@ -4,6 +4,11 @@ import type {
   Result,
 } from "@/services/result/types";
 import type {
+  SearchEngineValue,
+  ThemeValue,
+  ViewModeValue,
+} from "@/services/storage/types";
+import type {
   CreateTabRequest,
   RemoveTabRequest,
   UpdateTabRequest,
@@ -129,6 +134,99 @@ const closeContent = (): void => {
   runtimeServiceDependencies.contentService.close();
 };
 
+const getTheme = async (): Promise<ThemeValue> => {
+  try {
+    const raw: unknown = await chrome.runtime.sendMessage({
+      type: MessageType.GET_THEME,
+    });
+    if (!isRuntimeResponse<ThemeValue>(raw)) {
+      throw new RuntimeServiceError("Unexpected response shape from GET_THEME");
+    }
+    return raw.result;
+  } catch (error) {
+    if (error instanceof RuntimeServiceError) throw error;
+    logger.error("Failed to get theme via runtime:", error);
+    throw new RuntimeServiceError("Failed to get theme", toError(error));
+  }
+};
+
+const setTheme = async (theme: ThemeValue): Promise<void> => {
+  try {
+    await chrome.runtime.sendMessage({ type: MessageType.SET_THEME, theme });
+  } catch (error) {
+    logger.error("Failed to set theme via runtime:", error);
+    throw new RuntimeServiceError("Failed to set theme", toError(error));
+  }
+};
+
+const getViewMode = async (): Promise<ViewModeValue> => {
+  try {
+    const raw: unknown = await chrome.runtime.sendMessage({
+      type: MessageType.GET_VIEW_MODE,
+    });
+    if (!isRuntimeResponse<ViewModeValue>(raw)) {
+      throw new RuntimeServiceError(
+        "Unexpected response shape from GET_VIEW_MODE",
+      );
+    }
+    return raw.result;
+  } catch (error) {
+    if (error instanceof RuntimeServiceError) throw error;
+    logger.error("Failed to get viewMode via runtime:", error);
+    throw new RuntimeServiceError("Failed to get viewMode", toError(error));
+  }
+};
+
+const setViewMode = async (viewMode: ViewModeValue): Promise<void> => {
+  try {
+    await chrome.runtime.sendMessage({
+      type: MessageType.SET_VIEW_MODE,
+      viewMode,
+    });
+  } catch (error) {
+    logger.error("Failed to set viewMode via runtime:", error);
+    throw new RuntimeServiceError("Failed to set viewMode", toError(error));
+  }
+};
+
+const getSearchEngines = async (): Promise<SearchEngineValue[]> => {
+  try {
+    const raw: unknown = await chrome.runtime.sendMessage({
+      type: MessageType.GET_SEARCH_ENGINES,
+    });
+    if (!isRuntimeResponse<SearchEngineValue[]>(raw)) {
+      throw new RuntimeServiceError(
+        "Unexpected response shape from GET_SEARCH_ENGINES",
+      );
+    }
+    return raw.result;
+  } catch (error) {
+    if (error instanceof RuntimeServiceError) throw error;
+    logger.error("Failed to get searchEngines via runtime:", error);
+    throw new RuntimeServiceError(
+      "Failed to get searchEngines",
+      toError(error),
+    );
+  }
+};
+
+const setSearchEngines = async (
+  engines: SearchEngineValue[],
+): Promise<void> => {
+  try {
+    await chrome.runtime.sendMessage({
+      type: MessageType.SET_SEARCH_ENGINES,
+      engines,
+    });
+  } catch (error) {
+    logger.error("Failed to set searchEngines via runtime:", error);
+    throw new RuntimeServiceError(
+      "Failed to set searchEngines",
+      toError(error),
+    );
+  }
+};
+
 const createRuntimeService = (): RuntimeService => ({
   createTab,
   updateTab,
@@ -137,6 +235,12 @@ const createRuntimeService = (): RuntimeService => ({
   openContent,
   closeContent,
   connectPort,
+  getTheme,
+  setTheme,
+  getViewMode,
+  setViewMode,
+  getSearchEngines,
+  setSearchEngines,
 });
 
 export const runtimeService = createRuntimeService();

--- a/src/services/runtime/types.ts
+++ b/src/services/runtime/types.ts
@@ -43,10 +43,39 @@ export enum MessageType {
   QUERY_RESULT = "QUERY_RESULT",
   SWITCH_VIEW_MODE = "SWITCH_VIEW_MODE",
   INVALIDATE_CACHE = "INVALIDATE_CACHE",
+  // Storage operations routed through background
+  GET_THEME = "GET_THEME",
+  SET_THEME = "SET_THEME",
+  GET_VIEW_MODE = "GET_VIEW_MODE",
+  SET_VIEW_MODE = "SET_VIEW_MODE",
+  GET_SEARCH_ENGINES = "GET_SEARCH_ENGINES",
+  SET_SEARCH_ENGINES = "SET_SEARCH_ENGINES",
+  // Background → UI notification when storage changes
+  STORAGE_CHANGED = "STORAGE_CHANGED",
 }
 
 export type InvalidateCacheKind = "Tab" | "Bookmark" | "History";
 
 export interface SwitchViewModeRequest {
   type: MessageType.SWITCH_VIEW_MODE;
+}
+
+/** Background から UI へのストレージ変更通知メッセージ */
+export interface StorageChangedMessage {
+  type: MessageType.STORAGE_CHANGED;
+  key: string;
+  value: unknown;
+}
+
+/**
+ * メッセージが STORAGE_CHANGED メッセージかどうかを確認する型ガード関数。
+ * @param message - 検証するメッセージ
+ * @returns STORAGE_CHANGED メッセージの場合は true
+ */
+export function isStorageChangedMessage(
+  message: unknown,
+): message is StorageChangedMessage {
+  if (typeof message !== "object" || message === null) return false;
+  const m = message as { type?: unknown; key?: unknown };
+  return m.type === MessageType.STORAGE_CHANGED && typeof m.key === "string";
 }


### PR DESCRIPTION
## Summary

Closes #127

- UI hooks (`useTheme`, `useViewMode`, `useSearchEngines`) now route all storage reads/writes through `runtimeService` instead of calling `storageService` directly
- Background service worker handles new message types: `GET_THEME`, `SET_THEME`, `GET_VIEW_MODE`, `SET_VIEW_MODE`, `GET_SEARCH_ENGINES`, `SET_SEARCH_ENGINES`
- Background broadcasts `STORAGE_CHANGED` message via `chrome.runtime.sendMessage` on `chrome.storage.onChanged` so UI hooks can react to external storage updates
- Hooks subscribe to `chrome.runtime.onMessage` at module level (consistent with existing pattern) and validate incoming values with `isValidTheme` / `isValidViewMode` / `isValidSearchEngines`
- HMR cleanup added to `useTheme` to remove listeners on hot module replacement

## Test plan

- [ ] Open popup and verify theme toggle (light/dark/system) persists correctly
- [ ] Switch view mode (popup ↔ sidepanel) and verify it persists
- [ ] Toggle search engines on/off and verify they persist
- [ ] Open two extension pages simultaneously; verify storage changes in one are reflected in the other
- [ ] `pnpm compile` passes with no type errors
- [ ] `pnpm check` passes with no lint/format issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR概要

UI層のサービス呼び出しをアーキテクチャの要件に合わせるため、ストレージ操作をUIフックから直接の`storageService`呼び出しからランタイムサービス経由に変更する大規模なリファクタリングです。

## 主な変更内容

### ランタイムサービスの拡張
- `RuntimeService`インターフェースにテーマ、ビューモード、検索エンジン関連のメソッドを追加
  - `getTheme()`, `setTheme(theme)`, `getViewMode()`, `setViewMode(viewMode)`, `getSearchEngines()`, `setSearchEngines(engines)`
- 対応するランタイムメッセージハンドラー実装で、バックグラウンドサービスワーカーを経由して`storageService`へ委譲

### バックグラウンドサービスの強化
- **汎用ブロードキャストヘルパー追加**: `broadcast()`メソッドでUI（ポップアップ/サイドパネル）向けメッセージの一元管理
- **ストレージ変更通知機能**: `chrome.storage.onChanged`イベントをリッスンして、`STORAGE_CHANGED`メッセージをUIへブロードキャスト
- **新規メッセージハンドラー**: GET_THEME, SET_THEME, GET_VIEW_MODE, SET_VIEW_MODE, GET_SEARCH_ENGINES, SET_SEARCH_ENGINESのハンドラー実装

### ランタイムメッセージング型の拡張
- `MessageType`列挙型に新規メッセージタイプを追加
- `StorageChangedMessage`インターフェースとそのバリデーション用ガード関数`isStorageChangedMessage()`を追加

### UIフックの全面刷新
**useTheme**, **useViewMode**, **useSearchEngines**全てで共通パターン：
- `storageService`を`runtimeService`に置き換え
- 初期化時にはリモート呼び出しで値を取得（エラー時はデフォルト値にフォールバック）
- 永続化時は`runtimeService`の対応メソッドで実行
- `chrome.runtime.onMessage`リスナーを登録し、バックグラウンドからの`STORAGE_CHANGED`通知を受信して内部状態を更新
- 値の検証（`isValidTheme`, `isValidViewMode`, `isValidSearchEngines`）を組み込み
- useThemeのみホットモジュールリプレイスメント時のリスナー削除処理を追加（メモリリーク防止）

## アーキテクチャ上の改善
- UI層が直接`storageService`を呼び出さず、全てランタイムサービス経由に統一
- バックグラウンドワーカーがストレージ変更のソースオブトゥルースになり、複数開いているUI間での一貫性を確保
- `useSyncExternalStore`パターンを維持しながら、データソースをランタイムメッセージングに変更

## テスト対象項目
- テーマの永続性（ライト/ダーク/システム）
- ビューモードの永続性（ポップアップ↔サイドパネル）
- 検索エンジン設定の永続性
- 複数のUI（ポップアップ・サイドパネル）間での外部ストレージ変更の同期
- 型チェック、リント、フォーマットの成功

<!-- end of auto-generated comment: release notes by coderabbit.ai -->