### PR TITLE
[Claude Code] refactor: route content service calls through runtime in popup

### DIFF
--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { contentService } from "@/services/content";
 import { runtimeService } from "@/services/runtime";
 import App from "./App";
 
@@ -9,7 +8,7 @@ const rootElement =
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === "CLOSE_POPUP") {
-    contentService.close();
+    runtimeService.closeContent();
   }
 });
 


### PR DESCRIPTION
## Summary

Closes #128

- `popup/main.tsx` の `CLOSE_POPUP` ハンドラが `contentService.close()` を直接呼び出していた箇所を `runtimeService.closeContent()` に置き換え
- `contentService` の直接インポートを削除

これにより、UIコンテキスト（popup）が `runtimeService` のみを参照するという設計方針に完全に準拠する。

## Test plan

- [ ] ポップアップが正常に開閉できること
- [ ] `CLOSE_POPUP` メッセージ受信時にウィンドウが閉じること
- [ ] `pnpm compile` が型エラーなしで通ること
- [ ] `pnpm check` がエラーなしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)