### PR TITLE
[Claude Code] refactor: replace time-based vim gg detection with state machine

### DIFF
--- a/src/features/search/hooks/useSearchKeyboard/hook.ts
+++ b/src/features/search/hooks/useSearchKeyboard/hook.ts
@@ -65,7 +65,7 @@ export default function useSearchKeyboard(
     params;
 
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [vimGState, setVimGState] = useState<"idle" | "g_pending">("idle");
+  const vimGStateRef = useRef<"idle" | "g_pending">("idle");
   const listRef = useRef<HTMLUListElement>(null);
 
   // キーバインドの統合
@@ -107,19 +107,19 @@ export default function useSearchKeyboard(
 
       // Vim風のgg（最初に移動）の処理
       if (opts.enableVimBindings && e.key === "g") {
-        if (vimGState === "g_pending") {
+        if (vimGStateRef.current === "g_pending") {
           e.preventDefault();
           setSelectedIndex(0);
-          setVimGState("idle");
+          vimGStateRef.current = "idle";
         } else {
-          setVimGState("g_pending");
+          vimGStateRef.current = "g_pending";
         }
         return;
       }
 
       // g_pending 中に g 以外のキーが来たらリセット
-      if (vimGState === "g_pending") {
-        setVimGState("idle");
+      if (vimGStateRef.current === "g_pending") {
+        vimGStateRef.current = "idle";
       }
 
       // キーバインドからアクションを検索
@@ -146,7 +146,6 @@ export default function useSearchKeyboard(
       keyBindings,
       selectedIndex,
       results.length,
-      vimGState,
     ],
   );
 

--- a/src/features/search/hooks/useSearchKeyboard/hook.ts
+++ b/src/features/search/hooks/useSearchKeyboard/hook.ts
@@ -106,7 +106,13 @@ export default function useSearchKeyboard(
       }
 
       // Vim風のgg（最初に移動）の処理
-      if (opts.enableVimBindings && e.key === "g") {
+      if (
+        opts.enableVimBindings &&
+        e.key === "g" &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.metaKey
+      ) {
         if (vimGStateRef.current === "g_pending") {
           e.preventDefault();
           setSelectedIndex(0);

--- a/src/features/search/hooks/useSearchKeyboard/hook.ts
+++ b/src/features/search/hooks/useSearchKeyboard/hook.ts
@@ -65,9 +65,8 @@ export default function useSearchKeyboard(
     params;
 
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [vimGState, setVimGState] = useState<"idle" | "g_pending">("idle");
   const listRef = useRef<HTMLUListElement>(null);
-  const lastKeyPressRef = useRef<string>("");
-  const lastKeyTimeRef = useRef<number>(0);
 
   // キーバインドの統合
   const keyBindings = useMemo<KeyBinding[]>(() => {
@@ -108,19 +107,19 @@ export default function useSearchKeyboard(
 
       // Vim風のgg（最初に移動）の処理
       if (opts.enableVimBindings && e.key === "g") {
-        const now = Date.now();
-        if (
-          lastKeyPressRef.current === "g" &&
-          now - lastKeyTimeRef.current < 500
-        ) {
+        if (vimGState === "g_pending") {
           e.preventDefault();
           setSelectedIndex(0);
-          lastKeyPressRef.current = "";
-          return;
+          setVimGState("idle");
+        } else {
+          setVimGState("g_pending");
         }
-        lastKeyPressRef.current = "g";
-        lastKeyTimeRef.current = now;
         return;
+      }
+
+      // g_pending 中に g 以外のキーが来たらリセット
+      if (vimGState === "g_pending") {
+        setVimGState("idle");
       }
 
       // キーバインドからアクションを検索
@@ -137,7 +136,6 @@ export default function useSearchKeyboard(
         );
 
         setSelectedIndex(newIndex);
-        lastKeyPressRef.current = "";
       }
     },
     [
@@ -148,6 +146,7 @@ export default function useSearchKeyboard(
       keyBindings,
       selectedIndex,
       results.length,
+      vimGState,
     ],
   );
 


### PR DESCRIPTION
## Summary

Closes #135

- `lastKeyPressRef` / `lastKeyTimeRef` による時間ベースの `gg` 検出を廃止
- `'idle' | 'g_pending'` の明示的なステートマシンに置き換え

### 変更前（時間ベース）
```typescript
// 'g' を2回 500ms 以内に押したら gg と判定
const now = Date.now();
if (lastKeyPressRef.current === "g" && now - lastKeyTimeRef.current < 500) { ... }
```

### 変更後（ステートマシン）
```typescript
if (vimGState === "g_pending") {
  // gg 確定 → 先頭へジャンプ
  setVimGState("idle");
} else {
  setVimGState("g_pending");
}
```

### 改善点
- `Date` のモックが不要になり、テストが容易になる
- 時間に依存しないため `g → 別キー → g` のような入力で誤検知しない
- 500ms というマジックナンバーが不要になる

## Test plan

- [ ] `j` / `k` / `G` による上下移動が正常に動作すること
- [ ] `gg` で先頭にジャンプすること
- [ ] `g` を単体で押してもジャンプしないこと
- [ ] `g → 別キー → g` で誤検知しないこと
- [ ] `pnpm compile` が型エラーなしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)