### PR TITLE
[Claude Code] refactor: split useSearchKeyboard into focused sub-hooks

### DIFF
--- a/src/features/search/hooks/useSearchKeyboard/hook.ts
+++ b/src/features/search/hooks/useSearchKeyboard/hook.ts
@@ -1,44 +1,8 @@
 /**
  * useSearchKeyboard - キーボードナビゲーションを管理するhook
- */
-
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  DEFAULT_OPTIONS,
-  EMACS_KEYBINDINGS,
-  STANDARD_KEYBINDINGS,
-  VIM_KEYBINDINGS,
-} from "./constants";
-import {
-  calculateNewIndex,
-  debounce,
-  findAction,
-  scrollToIndex,
-} from "./helper";
-import type {
-  KeyBinding,
-  UseSearchKeyboardOptions,
-  UseSearchKeyboardParams,
-  UseSearchKeyboardReturn,
-} from "./types";
-
-/**
- * キーボードナビゲーションを管理するhook
  *
- * @description
- * このhookは以下の機能を提供します：
- * - Arrowキーによるナビゲーション
- * - Vim風キーバインド（j/k/g/G）
- * - Emacs風キーバインド（Ctrl+N/P）
- * - Home/End/PageUp/PageDownキー
- * - Enter/Tab/Backspace/Escapeキー
- * - IME入力中の誤動作防止
- * - スムーズスクロール
- * - キー操作のデバウンス（連打対策）
- *
- * @param params - パラメータ
- * @param options - オプション設定
- * @returns キーボード操作関数とstate
+ * useNavigationKey / useSubmitKey / useEscapeKey を束ねるオーケストレーター。
+ * 各サブhookは単独でテスト・拡張可能。
  *
  * @example
  * ```tsx
@@ -56,6 +20,19 @@ import type {
  * );
  * ```
  */
+
+import { useCallback, useMemo } from "react";
+import { DEFAULT_OPTIONS } from "./constants";
+import { debounce } from "./helper";
+import type {
+  UseSearchKeyboardOptions,
+  UseSearchKeyboardParams,
+  UseSearchKeyboardReturn,
+} from "./types";
+import useEscapeKey from "./useEscapeKey";
+import useNavigationKey from "./useNavigationKey";
+import useSubmitKey from "./useSubmitKey";
+
 export default function useSearchKeyboard(
   params: UseSearchKeyboardParams,
   options: UseSearchKeyboardOptions = {},
@@ -64,181 +41,52 @@ export default function useSearchKeyboard(
   const { results, isComposing, onSelect, onTab, onBackspace, onEscape } =
     params;
 
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const vimGStateRef = useRef<"idle" | "g_pending">("idle");
-  const listRef = useRef<HTMLUListElement>(null);
+  const navigation = useNavigationKey(
+    { resultsLength: results.length, isComposing },
+    opts,
+  );
 
-  // キーバインドの統合
-  const keyBindings = useMemo<KeyBinding[]>(() => {
-    const bindings = [...STANDARD_KEYBINDINGS];
-
-    if (opts.enableVimBindings) {
-      bindings.push(...VIM_KEYBINDINGS);
-    }
-
-    if (opts.enableEmacsBindings) {
-      bindings.push(...EMACS_KEYBINDINGS);
-    }
-
-    return bindings;
-  }, [opts.enableVimBindings, opts.enableEmacsBindings]);
-
-  // 選択項目が変更されたらスクロール
-  useEffect(() => {
-    scrollToIndex(listRef, selectedIndex, opts.scrollBehavior);
-  }, [selectedIndex, opts.scrollBehavior]);
-
-  /**
-   * インデックスをリセット
-   */
-  const resetSelectedIndex = useCallback(() => {
-    setSelectedIndex(0);
-  }, []);
-
-  /**
-   * ナビゲーションキーのハンドラー
-   */
-  const handleNavigationKey = useCallback(
-    (e: React.KeyboardEvent) => {
-      // IME入力中は無効化
-      if (opts.disableOnComposing && isComposing) {
-        return;
-      }
-
-      // Vim風のgg（最初に移動）の処理
-      if (
-        opts.enableVimBindings &&
-        e.key === "g" &&
-        !e.ctrlKey &&
-        !e.altKey &&
-        !e.metaKey
-      ) {
-        if (vimGStateRef.current === "g_pending") {
-          e.preventDefault();
-          setSelectedIndex(0);
-          vimGStateRef.current = "idle";
-        } else {
-          vimGStateRef.current = "g_pending";
-        }
-        return;
-      }
-
-      // g_pending 中に g 以外のキーが来たらリセット
-      if (vimGStateRef.current === "g_pending") {
-        vimGStateRef.current = "idle";
-      }
-
-      // キーバインドからアクションを検索
-      const action = findAction(e, keyBindings);
-
-      if (action) {
-        e.preventDefault();
-
-        const newIndex = calculateNewIndex(
-          action,
-          selectedIndex,
-          results.length,
-          opts.pageStep,
-        );
-
-        setSelectedIndex(newIndex);
-      }
-    },
-    [
-      opts.disableOnComposing,
-      opts.enableVimBindings,
-      opts.pageStep,
+  const submit = useSubmitKey(
+    {
+      results,
+      selectedIndex: navigation.selectedIndex,
       isComposing,
-      keyBindings,
-      selectedIndex,
-      results.length,
-    ],
-  );
-
-  /**
-   * Enterキーのハンドラー
-   */
-  const handleEnterKey = useCallback(
-    (e: React.KeyboardEvent) => {
-      // IME入力中は無効化
-      if (opts.disableOnComposing && isComposing) {
-        return;
-      }
-
-      if (e.key === "Enter") {
-        e.preventDefault();
-        const selectedResult = results[selectedIndex];
-        if (selectedResult) {
-          onSelect(selectedResult);
-        }
-      }
+      onSelect,
+      onTab,
+      onBackspace,
     },
-    [opts.disableOnComposing, isComposing, results, selectedIndex, onSelect],
+    opts,
   );
 
-  /**
-   * Tabキーのハンドラー
-   */
-  const handleTabKey = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Tab") {
-        e.preventDefault();
-        // IME入力中は無効化
-        if (opts.disableOnComposing && isComposing) {
-          return;
-        }
-        onTab?.();
-      }
-    },
-    [opts.disableOnComposing, isComposing, onTab],
-  );
+  const escapeKey = useEscapeKey({ onEscape });
 
-  /**
-   * Backspaceキーのハンドラー
-   */
-  const handleBackspaceKey = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Backspace") {
-        onBackspace?.();
-      }
-    },
-    [onBackspace],
-  );
+  const {
+    handleNavigationKey,
+    setSelectedIndex,
+    resetSelectedIndex,
+    selectedIndex,
+    listRef,
+  } = navigation;
+  const { handleEnterKey, handleTabKey, handleBackspaceKey } = submit;
+  const { handleEscapeKey } = escapeKey;
 
-  /**
-   * Escapeキーのハンドラー
-   */
-  const handleEscapeKey = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onEscape?.();
-      }
-    },
-    [onEscape],
-  );
-
-  /**
-   * すべてのキーイベントを統合したハンドラー
-   */
   const handleKeyDownRaw = useCallback(
     (e: React.KeyboardEvent) => {
       handleNavigationKey(e);
+      handleEscapeKey(e);
       handleEnterKey(e);
       handleTabKey(e);
       handleBackspaceKey(e);
-      handleEscapeKey(e);
     },
     [
       handleNavigationKey,
+      handleEscapeKey,
       handleEnterKey,
       handleTabKey,
       handleBackspaceKey,
-      handleEscapeKey,
     ],
   );
 
-  // デバウンス処理
   const handleKeyDown = useMemo(() => {
     if (opts.keyDebounceMs > 0) {
       return debounce(handleKeyDownRaw, opts.keyDebounceMs);

--- a/src/features/search/hooks/useSearchKeyboard/useEscapeKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useEscapeKey.ts
@@ -12,6 +12,11 @@ interface UseEscapeKeyReturn {
   handleEscapeKey: (e: React.KeyboardEvent) => void;
 }
 
+/**
+ * Escape キーによるクローズ・クリアを管理するhook
+ * @param params パラメータ（Escape 押下時のコールバック）
+ * @returns Escape キーハンドラー
+ */
 export default function useEscapeKey(
   params: UseEscapeKeyParams,
 ): UseEscapeKeyReturn {

--- a/src/features/search/hooks/useSearchKeyboard/useEscapeKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useEscapeKey.ts
@@ -1,0 +1,31 @@
+/**
+ * useEscapeKey - Escape キーによるクローズ・クリアを管理するhook
+ */
+
+import { useCallback } from "react";
+
+interface UseEscapeKeyParams {
+  onEscape?: () => void;
+}
+
+interface UseEscapeKeyReturn {
+  handleEscapeKey: (e: React.KeyboardEvent) => void;
+}
+
+export default function useEscapeKey(
+  params: UseEscapeKeyParams,
+): UseEscapeKeyReturn {
+  const { onEscape } = params;
+
+  const handleEscapeKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onEscape?.();
+      }
+    },
+    [onEscape],
+  );
+
+  return { handleEscapeKey };
+}

--- a/src/features/search/hooks/useSearchKeyboard/useNavigationKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useNavigationKey.ts
@@ -31,7 +31,7 @@ export default function useNavigationKey(
   const { resultsLength, isComposing } = params;
 
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [vimGState, setVimGState] = useState<"idle" | "g_pending">("idle");
+  const vimGStateRef = useRef<"idle" | "g_pending">("idle");
   const listRef = useRef<HTMLUListElement>(null);
 
   const keyBindings = useMemo<KeyBinding[]>(() => {
@@ -53,19 +53,19 @@ export default function useNavigationKey(
 
       // Vim風のgg（最初に移動）の処理
       if (opts.enableVimBindings && e.key === "g") {
-        if (vimGState === "g_pending") {
+        if (vimGStateRef.current === "g_pending") {
           e.preventDefault();
           setSelectedIndex(0);
-          setVimGState("idle");
+          vimGStateRef.current = "idle";
         } else {
-          setVimGState("g_pending");
+          vimGStateRef.current = "g_pending";
         }
         return;
       }
 
       // g_pending 中に g 以外のキーが来たらリセット
-      if (vimGState === "g_pending") {
-        setVimGState("idle");
+      if (vimGStateRef.current === "g_pending") {
+        vimGStateRef.current = "idle";
       }
 
       const action = findAction(e, keyBindings);
@@ -89,7 +89,6 @@ export default function useNavigationKey(
       keyBindings,
       selectedIndex,
       resultsLength,
-      vimGState,
     ],
   );
 

--- a/src/features/search/hooks/useSearchKeyboard/useNavigationKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useNavigationKey.ts
@@ -1,0 +1,103 @@
+/**
+ * useNavigationKey - Arrow / Vim / Emacs キーによるナビゲーションを管理するhook
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  EMACS_KEYBINDINGS,
+  STANDARD_KEYBINDINGS,
+  VIM_KEYBINDINGS,
+} from "./constants";
+import { calculateNewIndex, findAction, scrollToIndex } from "./helper";
+import type { KeyBinding, UseSearchKeyboardOptions } from "./types";
+
+interface UseNavigationKeyParams {
+  resultsLength: number;
+  isComposing: boolean;
+}
+
+interface UseNavigationKeyReturn {
+  selectedIndex: number;
+  listRef: React.RefObject<HTMLUListElement | null>;
+  setSelectedIndex: (index: number) => void;
+  resetSelectedIndex: () => void;
+  handleNavigationKey: (e: React.KeyboardEvent) => void;
+}
+
+export default function useNavigationKey(
+  params: UseNavigationKeyParams,
+  opts: Required<UseSearchKeyboardOptions>,
+): UseNavigationKeyReturn {
+  const { resultsLength, isComposing } = params;
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [vimGState, setVimGState] = useState<"idle" | "g_pending">("idle");
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const keyBindings = useMemo<KeyBinding[]>(() => {
+    const bindings = [...STANDARD_KEYBINDINGS];
+    if (opts.enableVimBindings) bindings.push(...VIM_KEYBINDINGS);
+    if (opts.enableEmacsBindings) bindings.push(...EMACS_KEYBINDINGS);
+    return bindings;
+  }, [opts.enableVimBindings, opts.enableEmacsBindings]);
+
+  useEffect(() => {
+    scrollToIndex(listRef, selectedIndex, opts.scrollBehavior);
+  }, [selectedIndex, opts.scrollBehavior]);
+
+  const resetSelectedIndex = useCallback(() => setSelectedIndex(0), []);
+
+  const handleNavigationKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (opts.disableOnComposing && isComposing) return;
+
+      // Vim風のgg（最初に移動）の処理
+      if (opts.enableVimBindings && e.key === "g") {
+        if (vimGState === "g_pending") {
+          e.preventDefault();
+          setSelectedIndex(0);
+          setVimGState("idle");
+        } else {
+          setVimGState("g_pending");
+        }
+        return;
+      }
+
+      // g_pending 中に g 以外のキーが来たらリセット
+      if (vimGState === "g_pending") {
+        setVimGState("idle");
+      }
+
+      const action = findAction(e, keyBindings);
+      if (action) {
+        e.preventDefault();
+        setSelectedIndex(
+          calculateNewIndex(
+            action,
+            selectedIndex,
+            resultsLength,
+            opts.pageStep,
+          ),
+        );
+      }
+    },
+    [
+      opts.disableOnComposing,
+      opts.enableVimBindings,
+      opts.pageStep,
+      isComposing,
+      keyBindings,
+      selectedIndex,
+      resultsLength,
+      vimGState,
+    ],
+  );
+
+  return {
+    selectedIndex,
+    listRef,
+    setSelectedIndex,
+    resetSelectedIndex,
+    handleNavigationKey,
+  };
+}

--- a/src/features/search/hooks/useSearchKeyboard/useNavigationKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useNavigationKey.ts
@@ -24,6 +24,12 @@ interface UseNavigationKeyReturn {
   handleNavigationKey: (e: React.KeyboardEvent) => void;
 }
 
+/**
+ * Arrow / Vim / Emacs キーによるナビゲーションを管理するhook
+ * @param params パラメータ（結果件数、IME状態）
+ * @param opts キーボードオプション
+ * @returns selectedIndex、listRef、ナビゲーション操作関数
+ */
 export default function useNavigationKey(
   params: UseNavigationKeyParams,
   opts: Required<UseSearchKeyboardOptions>,
@@ -52,7 +58,13 @@ export default function useNavigationKey(
       if (opts.disableOnComposing && isComposing) return;
 
       // Vim風のgg（最初に移動）の処理
-      if (opts.enableVimBindings && e.key === "g") {
+      if (
+        opts.enableVimBindings &&
+        e.key === "g" &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.metaKey
+      ) {
         if (vimGStateRef.current === "g_pending") {
           e.preventDefault();
           setSelectedIndex(0);

--- a/src/features/search/hooks/useSearchKeyboard/useSubmitKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useSubmitKey.ts
@@ -1,0 +1,62 @@
+/**
+ * useSubmitKey - Enter / Tab / Backspace キーによる選択・補完を管理するhook
+ */
+
+import { useCallback } from "react";
+import type { Kind, Result } from "@/services/result";
+import type { UseSearchKeyboardOptions } from "./types";
+
+interface UseSubmitKeyParams {
+  results: Result<Kind>[];
+  selectedIndex: number;
+  isComposing: boolean;
+  onSelect: (result: Result<Kind>) => void;
+  onTab?: () => void;
+  onBackspace?: () => void;
+}
+
+interface UseSubmitKeyReturn {
+  handleEnterKey: (e: React.KeyboardEvent) => void;
+  handleTabKey: (e: React.KeyboardEvent) => void;
+  handleBackspaceKey: (e: React.KeyboardEvent) => void;
+}
+
+export default function useSubmitKey(
+  params: UseSubmitKeyParams,
+  opts: Pick<Required<UseSearchKeyboardOptions>, "disableOnComposing">,
+): UseSubmitKeyReturn {
+  const { results, selectedIndex, isComposing, onSelect, onTab, onBackspace } =
+    params;
+
+  const handleEnterKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (opts.disableOnComposing && isComposing) return;
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const selectedResult = results[selectedIndex];
+        if (selectedResult) onSelect(selectedResult);
+      }
+    },
+    [opts.disableOnComposing, isComposing, results, selectedIndex, onSelect],
+  );
+
+  const handleTabKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Tab") {
+        e.preventDefault();
+        if (opts.disableOnComposing && isComposing) return;
+        onTab?.();
+      }
+    },
+    [opts.disableOnComposing, isComposing, onTab],
+  );
+
+  const handleBackspaceKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Backspace") onBackspace?.();
+    },
+    [onBackspace],
+  );
+
+  return { handleEnterKey, handleTabKey, handleBackspaceKey };
+}

--- a/src/features/search/hooks/useSearchKeyboard/useSubmitKey.ts
+++ b/src/features/search/hooks/useSearchKeyboard/useSubmitKey.ts
@@ -21,6 +21,12 @@ interface UseSubmitKeyReturn {
   handleBackspaceKey: (e: React.KeyboardEvent) => void;
 }
 
+/**
+ * Enter / Tab / Backspace キーによる選択・補完を管理するhook
+ * @param params パラメータ（結果リスト、選択インデックス、コールバック）
+ * @param opts キーボードオプション
+ * @returns Enter / Tab / Backspace キーハンドラー
+ */
 export default function useSubmitKey(
   params: UseSubmitKeyParams,
   opts: Pick<Required<UseSearchKeyboardOptions>, "disableOnComposing">,


### PR DESCRIPTION
## Summary

Closes #125

`useSearchKeyboard` から3つの責務を持つサブhookを抽出し、`useSearchKeyboard` 自身はオーケストレーターに:

| Hook | 責務 |
|---|---|
| `useNavigationKey` | Arrow/Vim/Emacs キーナビゲーション、`selectedIndex` 管理 |
| `useSubmitKey` | Enter（選択）/ Tab（補完）/ Backspace ハンドラ |
| `useEscapeKey` | Escape ハンドラ |

`useSearchKeyboard` は3つを束ねて同じ公開インターフェースを返すため、`SearchApp` 側の変更は不要。

また `useNavigationKey` では vim `gg` 検出を時間ベースから `'idle' | 'g_pending'` ステートマシンに変更（#135 の内容を含む）。

## Test plan

- [ ] Arrow キーで上下移動できること
- [ ] `gg` で先頭にジャンプできること（vim bindings 有効時）
- [ ] Enter でアイテムが選択されること
- [ ] Escape でポップアップが閉じること
- [ ] `pnpm compile` が型エラーなしで通ること
- [ ] `pnpm check` がエラーなしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)